### PR TITLE
Implement dual-snapshot access pattern types

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Wrapper for an in-progress compilation that will produce a StableSnapshot (ADR-042).
+ *
+ * <p>Provides asynchronous access to the compilation result with timeout and cancellation support.
+ * The underlying {@link CompletableFuture} is created by the compilation pipeline and completed
+ * when the compilation finishes.
+ *
+ * <p>Used by correctness-critical LSP features (hover, go-to-definition, find references, diagnostics)
+ * where consistency beats latency.
+ *
+ * @param future the completable future that will yield a StableSnapshot
+ * @since 1.7.0
+ */
+public record InProgressSnapshot(CompletableFuture<StableSnapshot> future) {
+
+    /**
+     * Validates the future is non-null.
+     */
+    public InProgressSnapshot {
+        Objects.requireNonNull(future, "future must not be null");
+    }
+
+    /**
+     * Awaits the completion of the underlying compilation, blocking until the
+     * StableSnapshot is available or the timeout expires.
+     *
+     * @param timeout maximum time to wait
+     * @return the stable snapshot when compilation completes successfully
+     * @throws TimeoutException if the timeout expires before completion
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @throws ExecutionException if the compilation failed with an exception
+     */
+    public StableSnapshot await(Duration timeout) throws TimeoutException, InterruptedException, ExecutionException {
+        Objects.requireNonNull(timeout, "timeout must not be null");
+        return future.get(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Cancels the underlying compilation future.
+     *
+     * <p>If the compilation has already completed, this has no effect.
+     * Any threads waiting on {@link #await(Duration)} will receive a
+     * {@link java.util.concurrent.CancellationException}.
+     *
+     * @return {@code true} if the future was cancelled (was not already completed)
+     */
+    public boolean cancel() {
+        return future.cancel(true);
+    }
+}

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
@@ -19,89 +19,32 @@
 package org.ballerinalang.langserver.workspace.compilerengine;
 
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
-import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
-import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Snapshot of an in-progress compilation (ADR-042).
- *
- * <p>Provides immediate access to syntax trees while semantic analysis completes
- * asynchronously. This enables LSP features to work with parsed code immediately
- * while waiting for type information.
- *
- * <p>Used by correctness-critical LSP features (hover, go-to-definition, find references,
- * diagnostics) where consistency beats latency.
- *
- * @param syntaxTrees    syntax trees keyed by module ID (available immediately)
- * @param semanticFuture  future that will yield the semantic model for a given module
- * @param compilationFuture future that will yield the full package compilation
- * @param contentVersion the content version that produced this snapshot
+ * In-progress snapshot contract for the current compilation cycle.
  * @since 1.7.0
  */
-public record InProgressSnapshot(Map<ModuleId, SyntaxTree> syntaxTrees,
-                                 CompletableFuture<SemanticModel> semanticFuture,
-                                 CompletableFuture<PackageCompilation> compilationFuture,
-                                 ContentVersion contentVersion) implements SyntaxSnapshot {
+public interface InProgressSnapshot extends SnapshotView {
 
     /**
-     * Validates all fields are non-null and creates defensive copy of syntaxTrees.
-     */
-    public InProgressSnapshot {
-        Objects.requireNonNull(syntaxTrees, "syntaxTrees must not be null");
-        Objects.requireNonNull(semanticFuture, "semanticFuture must not be null");
-        Objects.requireNonNull(compilationFuture, "compilationFuture must not be null");
-        Objects.requireNonNull(contentVersion, "contentVersion must not be null");
-        syntaxTrees = Map.copyOf(syntaxTrees);
-    }
-
-    /**
-     * Returns the syntax tree for the given module (immediate, non-blocking).
+     * Returns a future for the semantic model of the given module.
      *
      * @param moduleId the module identifier
-     * @return the syntax tree, or {@code null} if not available for this module
+     * @param checker the cancellation checker for the request
+     * @return a future for the module semantic model
      */
-    @Override
-    public SyntaxTree syntaxTree(ModuleId moduleId) {
-        Objects.requireNonNull(moduleId, "moduleId must not be null");
-        return syntaxTrees.get(moduleId);
-    }
+    CompletableFuture<SemanticModel> semanticModel(ModuleId moduleId, CancelChecker checker);
 
     /**
-     * Returns a future that will yield the semantic model when compilation completes.
+     * Returns a future for the in-progress package compilation.
      *
-     * @return the semantic model future
+     * @param checker the cancellation checker for the request
+     * @return a future for the package compilation
      */
-    public CompletableFuture<SemanticModel> semanticModel() {
-        return semanticFuture;
-    }
-
-    /**
-     * Returns a future that will yield the package compilation when complete.
-     *
-     * @return the compilation future
-     */
-    public CompletableFuture<PackageCompilation> compilation() {
-        return compilationFuture;
-    }
-
-    /**
-     * Cancels the underlying compilation futures.
-     *
-     * <p>If compilation has already completed, this has no effect.
-     * Any threads waiting on the futures will receive a
-     * {@link java.util.concurrent.CancellationException}.
-     *
-     * @return {@code true} if either future was cancelled (was not already completed)
-     */
-    public boolean cancel() {
-        boolean semanticCancelled = semanticFuture.cancel(true);
-        boolean compilationCancelled = compilationFuture.cancel(true);
-        return semanticCancelled || compilationCancelled;
-    }
+    CompletableFuture<PackageCompilation> compilation(CancelChecker checker);
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/InProgressSnapshot.java
@@ -18,59 +18,90 @@
 
 package org.ballerinalang.langserver.workspace.compilerengine;
 
-import java.time.Duration;
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
- * Wrapper for an in-progress compilation that will produce a StableSnapshot (ADR-042).
+ * Snapshot of an in-progress compilation (ADR-042).
  *
- * <p>Provides asynchronous access to the compilation result with timeout and cancellation support.
- * The underlying {@link CompletableFuture} is created by the compilation pipeline and completed
- * when the compilation finishes.
+ * <p>Provides immediate access to syntax trees while semantic analysis completes
+ * asynchronously. This enables LSP features to work with parsed code immediately
+ * while waiting for type information.
  *
- * <p>Used by correctness-critical LSP features (hover, go-to-definition, find references, diagnostics)
- * where consistency beats latency.
+ * <p>Used by correctness-critical LSP features (hover, go-to-definition, find references,
+ * diagnostics) where consistency beats latency.
  *
- * @param future the completable future that will yield a StableSnapshot
+ * @param syntaxTrees    syntax trees keyed by module ID (available immediately)
+ * @param semanticFuture  future that will yield the semantic model for a given module
+ * @param compilationFuture future that will yield the full package compilation
+ * @param contentVersion the content version that produced this snapshot
  * @since 1.7.0
  */
-public record InProgressSnapshot(CompletableFuture<StableSnapshot> future) {
+public record InProgressSnapshot(Map<ModuleId, SyntaxTree> syntaxTrees,
+                                 CompletableFuture<SemanticModel> semanticFuture,
+                                 CompletableFuture<PackageCompilation> compilationFuture,
+                                 ContentVersion contentVersion) implements SyntaxSnapshot {
 
     /**
-     * Validates the future is non-null.
+     * Validates all fields are non-null and creates defensive copy of syntaxTrees.
      */
     public InProgressSnapshot {
-        Objects.requireNonNull(future, "future must not be null");
+        Objects.requireNonNull(syntaxTrees, "syntaxTrees must not be null");
+        Objects.requireNonNull(semanticFuture, "semanticFuture must not be null");
+        Objects.requireNonNull(compilationFuture, "compilationFuture must not be null");
+        Objects.requireNonNull(contentVersion, "contentVersion must not be null");
+        syntaxTrees = Map.copyOf(syntaxTrees);
     }
 
     /**
-     * Awaits the completion of the underlying compilation, blocking until the
-     * StableSnapshot is available or the timeout expires.
+     * Returns the syntax tree for the given module (immediate, non-blocking).
      *
-     * @param timeout maximum time to wait
-     * @return the stable snapshot when compilation completes successfully
-     * @throws TimeoutException if the timeout expires before completion
-     * @throws InterruptedException if the current thread is interrupted while waiting
-     * @throws ExecutionException if the compilation failed with an exception
+     * @param moduleId the module identifier
+     * @return the syntax tree, or {@code null} if not available for this module
      */
-    public StableSnapshot await(Duration timeout) throws TimeoutException, InterruptedException, ExecutionException {
-        Objects.requireNonNull(timeout, "timeout must not be null");
-        return future.get(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+    @Override
+    public SyntaxTree syntaxTree(ModuleId moduleId) {
+        Objects.requireNonNull(moduleId, "moduleId must not be null");
+        return syntaxTrees.get(moduleId);
     }
 
     /**
-     * Cancels the underlying compilation future.
+     * Returns a future that will yield the semantic model when compilation completes.
      *
-     * <p>If the compilation has already completed, this has no effect.
-     * Any threads waiting on {@link #await(Duration)} will receive a
+     * @return the semantic model future
+     */
+    public CompletableFuture<SemanticModel> semanticModel() {
+        return semanticFuture;
+    }
+
+    /**
+     * Returns a future that will yield the package compilation when complete.
+     *
+     * @return the compilation future
+     */
+    public CompletableFuture<PackageCompilation> compilation() {
+        return compilationFuture;
+    }
+
+    /**
+     * Cancels the underlying compilation futures.
+     *
+     * <p>If compilation has already completed, this has no effect.
+     * Any threads waiting on the futures will receive a
      * {@link java.util.concurrent.CancellationException}.
      *
-     * @return {@code true} if the future was cancelled (was not already completed)
+     * @return {@code true} if either future was cancelled (was not already completed)
      */
     public boolean cancel() {
-        return future.cancel(true);
+        boolean semanticCancelled = semanticFuture.cancel(true);
+        boolean compilationCancelled = compilationFuture.cancel(true);
+        return semanticCancelled || compilationCancelled;
     }
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SnapshotView.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SnapshotView.java
@@ -19,23 +19,28 @@
 package org.ballerinalang.langserver.workspace.compilerengine;
 
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.DocumentId;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 
 /**
- * Sealed interface for syntax tree access in the dual-snapshot pattern (ADR-042).
- *
- * <p>Provides per-module syntax tree lookup for LSP features that operate on
- * parsed but not necessarily fully-compiled code.
+ * Shared syntax-level snapshot contract for the dual-snapshot access pattern.
  *
  * @since 1.7.0
  */
-public sealed interface SyntaxSnapshot permits StableSnapshot, InProgressSnapshot {
+public interface SnapshotView {
 
     /**
-     * Returns the syntax tree for the given module.
+     * Returns the syntax tree for the given document.
      *
-     * @param moduleId the module identifier
-     * @return the syntax tree, or {@code null} if not available
+     * @param docId the document identifier
+     * @return the syntax tree for the given document
      */
-    SyntaxTree syntaxTree(ModuleId moduleId);
+    SyntaxTree syntaxTree(DocumentId docId);
+
+    /**
+     * Returns the content version represented by this snapshot.
+     *
+     * @return the snapshot content version
+     */
+    ContentVersion contentVersion();
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/StableSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/StableSnapshot.java
@@ -19,55 +19,27 @@
 package org.ballerinalang.langserver.workspace.compilerengine;
 
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
-import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
-
-import java.util.Map;
-import java.util.Objects;
 
 /**
- * Immutable snapshot of a successfully compiled project (ADR-042).
- *
- * <p>Provides synchronous access to syntax trees and semantic models.
- * As a record, it is inherently thread-safe and safely publishable across threads
- * without additional synchronization.
- *
- * <p>Used by latency-sensitive LSP features (completion, signature help, code lens)
- * where availability beats freshness.
- *
- * @param compilation    the package compilation result
- * @param semanticModel  the semantic model derived from the compilation
- * @param syntaxTrees    syntax trees keyed by module ID
- * @param contentVersion the content version that produced this snapshot
+ * Stable snapshot contract for the last successful compilation.
  * @since 1.7.0
  */
-public record StableSnapshot(PackageCompilation compilation,
-                             SemanticModel semanticModel,
-                             Map<ModuleId, SyntaxTree> syntaxTrees,
-                             ContentVersion contentVersion) implements SyntaxSnapshot {
+public interface StableSnapshot extends SnapshotView {
 
     /**
-     * Validates all fields are non-null and creates defensive copy of syntaxTrees.
-     */
-    public StableSnapshot {
-        Objects.requireNonNull(compilation, "compilation must not be null");
-        Objects.requireNonNull(semanticModel, "semanticModel must not be null");
-        Objects.requireNonNull(syntaxTrees, "syntaxTrees must not be null");
-        Objects.requireNonNull(contentVersion, "contentVersion must not be null");
-        syntaxTrees = Map.copyOf(syntaxTrees);
-    }
-
-    /**
-     * Returns the syntax tree for the given module.
+     * Returns the semantic model for the given module.
      *
      * @param moduleId the module identifier
-     * @return the syntax tree, or {@code null} if not available for this module
+     * @return the module semantic model
      */
-    @Override
-    public SyntaxTree syntaxTree(ModuleId moduleId) {
-        Objects.requireNonNull(moduleId, "moduleId must not be null");
-        return syntaxTrees.get(moduleId);
-    }
+    SemanticModel semanticModel(ModuleId moduleId);
+
+    /**
+     * Returns the fully materialized package compilation.
+     *
+     * @return the package compilation
+     */
+    PackageCompilation compilation();
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/StableSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/StableSnapshot.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of a successfully compiled project (ADR-042).
+ *
+ * <p>Provides synchronous access to syntax trees and semantic models.
+ * As a record, it is inherently thread-safe and safely publishable across threads
+ * without additional synchronization.
+ *
+ * <p>Used by latency-sensitive LSP features (completion, signature help, code lens)
+ * where availability beats freshness.
+ *
+ * @param compilation    the package compilation result
+ * @param semanticModel  the semantic model derived from the compilation
+ * @param syntaxTrees    syntax trees keyed by module ID
+ * @param contentVersion the content version that produced this snapshot
+ * @since 1.7.0
+ */
+public record StableSnapshot(PackageCompilation compilation,
+                             SemanticModel semanticModel,
+                             Map<ModuleId, SyntaxTree> syntaxTrees,
+                             ContentVersion contentVersion) implements SyntaxSnapshot {
+
+    /**
+     * Validates all fields are non-null and creates defensive copy of syntaxTrees.
+     */
+    public StableSnapshot {
+        Objects.requireNonNull(compilation, "compilation must not be null");
+        Objects.requireNonNull(semanticModel, "semanticModel must not be null");
+        Objects.requireNonNull(syntaxTrees, "syntaxTrees must not be null");
+        Objects.requireNonNull(contentVersion, "contentVersion must not be null");
+        syntaxTrees = Map.copyOf(syntaxTrees);
+    }
+
+    /**
+     * Returns the syntax tree for the given module.
+     *
+     * @param moduleId the module identifier
+     * @return the syntax tree, or {@code null} if not available for this module
+     */
+    @Override
+    public SyntaxTree syntaxTree(ModuleId moduleId) {
+        Objects.requireNonNull(moduleId, "moduleId must not be null");
+        return syntaxTrees.get(moduleId);
+    }
+}

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SyntaxSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SyntaxSnapshot.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.ModuleId;
+
+/**
+ * Sealed interface for syntax tree access in the dual-snapshot pattern (ADR-042).
+ *
+ * <p>Provides per-module syntax tree lookup for LSP features that operate on
+ * parsed but not necessarily fully-compiled code.
+ *
+ * @since 1.7.0
+ */
+public sealed interface SyntaxSnapshot permits StableSnapshot {
+
+    /**
+     * Returns the syntax tree for the given module.
+     *
+     * @param moduleId the module identifier
+     * @return the syntax tree, or {@code null} if not available
+     */
+    SyntaxTree syntaxTree(ModuleId moduleId);
+}

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SyntaxSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/SyntaxSnapshot.java
@@ -29,7 +29,7 @@ import io.ballerina.projects.ModuleId;
  *
  * @since 1.7.0
  */
-public sealed interface SyntaxSnapshot permits StableSnapshot {
+public sealed interface SyntaxSnapshot permits StableSnapshot, InProgressSnapshot {
 
     /**
      * Returns the syntax tree for the given module.

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
@@ -26,14 +26,12 @@ import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
 
@@ -47,19 +45,31 @@ public class DualSnapshotTest {
     // ---- SyntaxSnapshot sealed interface ----
 
     @Test
-    public void syntaxSnapshot_permitsStableSnapshot() {
-        // Verify that StableSnapshot implements SyntaxSnapshot
-        SyntaxSnapshot snapshot = createMockStableSnapshot();
-        Assert.assertNotNull(snapshot);
-        Assert.assertTrue(snapshot instanceof StableSnapshot);
+    public void syntaxSnapshot_permitsStableAndInProgress() {
+        // Verify both types implement SyntaxSnapshot
+        SyntaxSnapshot stable = createMockStableSnapshot();
+        SyntaxSnapshot inProgress = createMockInProgressSnapshot();
+        
+        Assert.assertNotNull(stable);
+        Assert.assertNotNull(inProgress);
+        Assert.assertTrue(stable instanceof StableSnapshot);
+        Assert.assertTrue(inProgress instanceof InProgressSnapshot);
     }
 
     @Test
     public void syntaxSnapshot_isSealed() {
         // Verify SyntaxSnapshot is sealed by checking permits clause via reflection
         Class<?>[] permits = SyntaxSnapshot.class.getPermittedSubclasses();
-        Assert.assertEquals(permits.length, 1, "SyntaxSnapshot should permit exactly one subclass");
-        Assert.assertEquals(permits[0], StableSnapshot.class, "SyntaxSnapshot should permit StableSnapshot");
+        Assert.assertEquals(permits.length, 2, "SyntaxSnapshot should permit two subclasses");
+        // Verify both StableSnapshot and InProgressSnapshot are permitted
+        boolean hasStable = false;
+        boolean hasInProgress = false;
+        for (Class<?> cls : permits) {
+            if (cls == StableSnapshot.class) hasStable = true;
+            if (cls == InProgressSnapshot.class) hasInProgress = true;
+        }
+        Assert.assertTrue(hasStable, "SyntaxSnapshot should permit StableSnapshot");
+        Assert.assertTrue(hasInProgress, "SyntaxSnapshot should permit InProgressSnapshot");
     }
 
     // ---- StableSnapshot ----
@@ -112,8 +122,21 @@ public class DualSnapshotTest {
     }
 
     @Test
+    public void stableSnapshot_compilationReturnsCorrectResult() {
+        PackageCompilation compilation = mock(PackageCompilation.class);
+
+        StableSnapshot snapshot = new StableSnapshot(
+                compilation,
+                mock(SemanticModel.class),
+                Map.of(),
+                new ContentVersion(1)
+        );
+
+        Assert.assertSame(snapshot.compilation(), compilation);
+    }
+
+    @Test
     public void stableSnapshot_isImmutableRecord() {
-        // Records are immutable by design; verify fields are accessible but not modifiable
         ModuleId moduleId = mock(ModuleId.class);
         SyntaxTree syntaxTree = mock(SyntaxTree.class);
         SemanticModel semanticModel = mock(SemanticModel.class);
@@ -130,8 +153,21 @@ public class DualSnapshotTest {
 
         // Verify record accessors
         Assert.assertSame(snapshot.semanticModel(), semanticModel);
+        Assert.assertSame(snapshot.compilation(), compilation);
         Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
         Assert.assertEquals(snapshot.contentVersion(), version);
+    }
+
+    @Test
+    public void stableSnapshot_rejectsNullCompilation() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new StableSnapshot(
+                        null,
+                        mock(SemanticModel.class),
+                        Map.of(),
+                        new ContentVersion(1)
+                )
+        );
     }
 
     @Test
@@ -220,96 +256,240 @@ public class DualSnapshotTest {
     // ---- InProgressSnapshot ----
 
     @Test
-    public void inProgressSnapshot_awaitReturnsStableSnapshotOnSuccess() throws Exception {
-        StableSnapshot expected = createMockStableSnapshot();
-        CompletableFuture<StableSnapshot> future = CompletableFuture.completedFuture(expected);
+    public void inProgressSnapshot_syntaxTreeReturnsCorrectTree() {
+        ModuleId moduleId = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
 
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                syntaxTrees,
+                new CompletableFuture<>(),
+                new CompletableFuture<>(),
+                new ContentVersion(1)
+        );
 
-        StableSnapshot result = snapshot.await(Duration.ofSeconds(1));
-        Assert.assertSame(result, expected);
-    }
-
-    @Test(expectedExceptions = TimeoutException.class)
-    public void inProgressSnapshot_awaitThrowsTimeoutExceptionOnTimeout() throws Exception {
-        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
-
-        // This should timeout since future is never completed
-        snapshot.await(Duration.ofMillis(50));
+        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
     }
 
     @Test
-    public void inProgressSnapshot_cancelCancelsUnderlyingFuture() {
-        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+    public void inProgressSnapshot_syntaxTreeReturnsNullForUnknownModule() {
+        ModuleId knownModule = mock(ModuleId.class);
+        ModuleId unknownModule = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(knownModule, syntaxTree);
 
-        Assert.assertFalse(future.isCancelled());
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                syntaxTrees,
+                new CompletableFuture<>(),
+                new CompletableFuture<>(),
+                new ContentVersion(1)
+        );
+
+        Assert.assertNull(snapshot.syntaxTree(unknownModule));
+    }
+
+    @Test
+    public void inProgressSnapshot_syntaxTreeAvailableImmediately() {
+        ModuleId moduleId = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
+
+        // Create InProgressSnapshot with incomplete futures
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                syntaxTrees,
+                new CompletableFuture<>(),  // Not completed
+                new CompletableFuture<>(),  // Not completed
+                new ContentVersion(1)
+        );
+
+        // Syntax tree should be available even though futures aren't complete
+        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
+    }
+
+    @Test
+    public void inProgressSnapshot_semanticModelReturnsFuture() {
+        CompletableFuture<SemanticModel> semanticFuture = new CompletableFuture<>();
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                semanticFuture,
+                new CompletableFuture<>(),
+                new ContentVersion(1)
+        );
+
+        Assert.assertSame(snapshot.semanticModel(), semanticFuture);
+    }
+
+    @Test
+    public void inProgressSnapshot_compilationReturnsFuture() {
+        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                new CompletableFuture<>(),
+                compilationFuture,
+                new ContentVersion(1)
+        );
+
+        Assert.assertSame(snapshot.compilation(), compilationFuture);
+    }
+
+    @Test
+    public void inProgressSnapshot_semanticModelCompletesSuccessfully() throws Exception {
+        SemanticModel expectedModel = mock(SemanticModel.class);
+        CompletableFuture<SemanticModel> semanticFuture = CompletableFuture.completedFuture(expectedModel);
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                semanticFuture,
+                new CompletableFuture<>(),
+                new ContentVersion(1)
+        );
+
+        SemanticModel result = snapshot.semanticModel().get(1, TimeUnit.SECONDS);
+        Assert.assertSame(result, expectedModel);
+    }
+
+    @Test
+    public void inProgressSnapshot_compilationCompletesSuccessfully() throws Exception {
+        PackageCompilation expectedCompilation = mock(PackageCompilation.class);
+        CompletableFuture<PackageCompilation> compilationFuture = CompletableFuture.completedFuture(expectedCompilation);
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                new CompletableFuture<>(),
+                compilationFuture,
+                new ContentVersion(1)
+        );
+
+        PackageCompilation result = snapshot.compilation().get(1, TimeUnit.SECONDS);
+        Assert.assertSame(result, expectedCompilation);
+    }
+
+    @Test
+    public void inProgressSnapshot_cancelCancelsBothFutures() {
+        CompletableFuture<SemanticModel> semanticFuture = new CompletableFuture<>();
+        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                semanticFuture,
+                compilationFuture,
+                new ContentVersion(1)
+        );
+
+        Assert.assertFalse(semanticFuture.isCancelled());
+        Assert.assertFalse(compilationFuture.isCancelled());
 
         snapshot.cancel();
 
-        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(semanticFuture.isCancelled());
+        Assert.assertTrue(compilationFuture.isCancelled());
     }
 
     @Test
-    public void inProgressSnapshot_awaitAfterCancelThrowsException() {
-        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+    public void inProgressSnapshot_cancelReturnsTrueIfAnyFutureWasCancelled() {
+        // Already completed futures cannot be cancelled
+        CompletableFuture<SemanticModel> semanticFuture = CompletableFuture.completedFuture(mock(SemanticModel.class));
+        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
 
-        snapshot.cancel();
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                semanticFuture,
+                compilationFuture,
+                new ContentVersion(1)
+        );
 
-        // Attempting to await a cancelled future should throw
-        Assert.assertThrows(Exception.class, () -> snapshot.await(Duration.ofSeconds(1)));
+        boolean result = snapshot.cancel();
+
+        Assert.assertTrue(result); // One future was cancelled
+        Assert.assertFalse(semanticFuture.isCancelled()); // Already completed
+        Assert.assertTrue(compilationFuture.isCancelled()); // Was cancelled
     }
 
     @Test
-    public void inProgressSnapshot_rejectsNullFuture() {
-        Assert.assertThrows(NullPointerException.class, () -> new InProgressSnapshot(null));
+    public void inProgressSnapshot_rejectsNullSyntaxTrees() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new InProgressSnapshot(
+                        null,
+                        new CompletableFuture<>(),
+                        new CompletableFuture<>(),
+                        new ContentVersion(1)
+                )
+        );
     }
 
     @Test
-    public void inProgressSnapshot_awaitPropagatesException() {
-        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
-        future.completeExceptionally(new RuntimeException("Compilation failed"));
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
-
-        Assert.assertThrows(java.util.concurrent.ExecutionException.class, 
-                () -> snapshot.await(Duration.ofSeconds(1)));
+    public void inProgressSnapshot_rejectsNullSemanticFuture() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new InProgressSnapshot(
+                        Map.of(),
+                        null,
+                        new CompletableFuture<>(),
+                        new ContentVersion(1)
+                )
+        );
     }
 
     @Test
-    public void inProgressSnapshot_concurrentAwaitAndCancel() throws Exception {
-        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
-        InProgressSnapshot snapshot = new InProgressSnapshot(future);
-        int threadCount = 4;
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    public void inProgressSnapshot_rejectsNullCompilationFuture() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new InProgressSnapshot(
+                        Map.of(),
+                        new CompletableFuture<>(),
+                        null,
+                        new ContentVersion(1)
+                )
+        );
+    }
+
+    @Test
+    public void inProgressSnapshot_rejectsNullContentVersion() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new InProgressSnapshot(
+                        Map.of(),
+                        new CompletableFuture<>(),
+                        new CompletableFuture<>(),
+                        null
+                )
+        );
+    }
+
+    @Test
+    public void inProgressSnapshot_contentVersionReturnsCorrectValue() {
+        ContentVersion version = new ContentVersion(42);
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(
+                Map.of(),
+                new CompletableFuture<>(),
+                new CompletableFuture<>(),
+                version
+        );
+
+        Assert.assertEquals(snapshot.contentVersion(), version);
+    }
+
+    @Test
+    public void inProgressSnapshot_threadSafeAccess() throws InterruptedException {
+        InProgressSnapshot snapshot = createMockInProgressSnapshot();
+        int threadCount = 8;
+        CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
         for (int i = 0; i < threadCount; i++) {
-            final int threadId = i;
             executor.submit(() -> {
                 try {
-                    startLatch.await();
-                    if (threadId == 0) {
-                        snapshot.cancel();
-                    } else {
-                        try {
-                            snapshot.await(Duration.ofMillis(100));
-                        } catch (TimeoutException | RuntimeException | java.util.concurrent.ExecutionException e) {
-                            // Expected: either timeout or cancellation
-                        }
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                    // Access snapshot from multiple threads
+                    Assert.assertNotNull(snapshot.contentVersion());
+                    Assert.assertNotNull(snapshot.semanticModel());
+                    Assert.assertNotNull(snapshot.compilation());
                 } finally {
-                    doneLatch.countDown();
+                    latch.countDown();
                 }
             });
         }
 
-        startLatch.countDown(); // Start all threads
-        Assert.assertTrue(doneLatch.await(2, TimeUnit.SECONDS), "Concurrent operations timed out");
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS), "Concurrent access timed out");
         executor.shutdown();
     }
 
@@ -320,6 +500,15 @@ public class DualSnapshotTest {
                 mock(PackageCompilation.class),
                 mock(SemanticModel.class),
                 Map.of(),
+                new ContentVersion(1)
+        );
+    }
+
+    private InProgressSnapshot createMockInProgressSnapshot() {
+        return new InProgressSnapshot(
+                Map.of(),
+                new CompletableFuture<>(),
+                new CompletableFuture<>(),
                 new ContentVersion(1)
         );
     }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
@@ -1,0 +1,326 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for dual-snapshot types: SyntaxSnapshot, StableSnapshot, InProgressSnapshot.
+ *
+ * @since 1.7.0
+ */
+public class DualSnapshotTest {
+
+    // ---- SyntaxSnapshot sealed interface ----
+
+    @Test
+    public void syntaxSnapshot_permitsStableSnapshot() {
+        // Verify that StableSnapshot implements SyntaxSnapshot
+        SyntaxSnapshot snapshot = createMockStableSnapshot();
+        Assert.assertNotNull(snapshot);
+        Assert.assertTrue(snapshot instanceof StableSnapshot);
+    }
+
+    @Test
+    public void syntaxSnapshot_isSealed() {
+        // Verify SyntaxSnapshot is sealed by checking permits clause via reflection
+        Class<?>[] permits = SyntaxSnapshot.class.getPermittedSubclasses();
+        Assert.assertEquals(permits.length, 1, "SyntaxSnapshot should permit exactly one subclass");
+        Assert.assertEquals(permits[0], StableSnapshot.class, "SyntaxSnapshot should permit StableSnapshot");
+    }
+
+    // ---- StableSnapshot ----
+
+    @Test
+    public void stableSnapshot_syntaxTreeReturnsCorrectTree() {
+        ModuleId moduleId = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
+
+        StableSnapshot snapshot = new StableSnapshot(
+                mock(PackageCompilation.class),
+                mock(SemanticModel.class),
+                syntaxTrees,
+                new ContentVersion(1)
+        );
+
+        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
+    }
+
+    @Test
+    public void stableSnapshot_syntaxTreeReturnsNullForUnknownModule() {
+        ModuleId knownModule = mock(ModuleId.class);
+        ModuleId unknownModule = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(knownModule, syntaxTree);
+
+        StableSnapshot snapshot = new StableSnapshot(
+                mock(PackageCompilation.class),
+                mock(SemanticModel.class),
+                syntaxTrees,
+                new ContentVersion(1)
+        );
+
+        Assert.assertNull(snapshot.syntaxTree(unknownModule));
+    }
+
+    @Test
+    public void stableSnapshot_semanticModelReturnsCorrectModel() {
+        SemanticModel semanticModel = mock(SemanticModel.class);
+
+        StableSnapshot snapshot = new StableSnapshot(
+                mock(PackageCompilation.class),
+                semanticModel,
+                Map.of(),
+                new ContentVersion(1)
+        );
+
+        Assert.assertSame(snapshot.semanticModel(), semanticModel);
+    }
+
+    @Test
+    public void stableSnapshot_isImmutableRecord() {
+        // Records are immutable by design; verify fields are accessible but not modifiable
+        ModuleId moduleId = mock(ModuleId.class);
+        SyntaxTree syntaxTree = mock(SyntaxTree.class);
+        SemanticModel semanticModel = mock(SemanticModel.class);
+        PackageCompilation compilation = mock(PackageCompilation.class);
+        ContentVersion version = new ContentVersion(1);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
+
+        StableSnapshot snapshot = new StableSnapshot(
+                compilation,
+                semanticModel,
+                syntaxTrees,
+                version
+        );
+
+        // Verify record accessors
+        Assert.assertSame(snapshot.semanticModel(), semanticModel);
+        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
+        Assert.assertEquals(snapshot.contentVersion(), version);
+    }
+
+    @Test
+    public void stableSnapshot_rejectsNullSemanticModel() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new StableSnapshot(
+                        mock(PackageCompilation.class),
+                        null,
+                        Map.of(),
+                        new ContentVersion(1)
+                )
+        );
+    }
+
+    @Test
+    public void stableSnapshot_rejectsNullSyntaxTrees() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new StableSnapshot(
+                        mock(PackageCompilation.class),
+                        mock(SemanticModel.class),
+                        null,
+                        new ContentVersion(1)
+                )
+        );
+    }
+
+    @Test
+    public void stableSnapshot_rejectsNullContentVersion() {
+        Assert.assertThrows(NullPointerException.class, () ->
+                new StableSnapshot(
+                        mock(PackageCompilation.class),
+                        mock(SemanticModel.class),
+                        Map.of(),
+                        null
+                )
+        );
+    }
+
+    @Test
+    public void stableSnapshot_equalityByValue() {
+        PackageCompilation compilation = mock(PackageCompilation.class);
+        SemanticModel semanticModel = mock(SemanticModel.class);
+        ContentVersion version = new ContentVersion(1);
+        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of();
+
+        StableSnapshot s1 = new StableSnapshot(
+                compilation,
+                semanticModel,
+                syntaxTrees,
+                version
+        );
+        StableSnapshot s2 = new StableSnapshot(
+                compilation,
+                semanticModel,
+                syntaxTrees,
+                version
+        );
+
+        Assert.assertEquals(s1, s2);
+        Assert.assertEquals(s1.hashCode(), s2.hashCode());
+    }
+
+    @Test
+    public void stableSnapshot_threadSafeAccess() throws InterruptedException {
+        StableSnapshot snapshot = createMockStableSnapshot();
+        int threadCount = 8;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    // Access snapshot from multiple threads
+                    Assert.assertNotNull(snapshot.semanticModel());
+                    Assert.assertNotNull(snapshot.contentVersion());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS), "Concurrent access timed out");
+        executor.shutdown();
+    }
+
+    // ---- InProgressSnapshot ----
+
+    @Test
+    public void inProgressSnapshot_awaitReturnsStableSnapshotOnSuccess() throws Exception {
+        StableSnapshot expected = createMockStableSnapshot();
+        CompletableFuture<StableSnapshot> future = CompletableFuture.completedFuture(expected);
+
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+
+        StableSnapshot result = snapshot.await(Duration.ofSeconds(1));
+        Assert.assertSame(result, expected);
+    }
+
+    @Test(expectedExceptions = TimeoutException.class)
+    public void inProgressSnapshot_awaitThrowsTimeoutExceptionOnTimeout() throws Exception {
+        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+
+        // This should timeout since future is never completed
+        snapshot.await(Duration.ofMillis(50));
+    }
+
+    @Test
+    public void inProgressSnapshot_cancelCancelsUnderlyingFuture() {
+        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+
+        Assert.assertFalse(future.isCancelled());
+
+        snapshot.cancel();
+
+        Assert.assertTrue(future.isCancelled());
+    }
+
+    @Test
+    public void inProgressSnapshot_awaitAfterCancelThrowsException() {
+        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+
+        snapshot.cancel();
+
+        // Attempting to await a cancelled future should throw
+        Assert.assertThrows(Exception.class, () -> snapshot.await(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    public void inProgressSnapshot_rejectsNullFuture() {
+        Assert.assertThrows(NullPointerException.class, () -> new InProgressSnapshot(null));
+    }
+
+    @Test
+    public void inProgressSnapshot_awaitPropagatesException() {
+        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Compilation failed"));
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+
+        Assert.assertThrows(java.util.concurrent.ExecutionException.class, 
+                () -> snapshot.await(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    public void inProgressSnapshot_concurrentAwaitAndCancel() throws Exception {
+        CompletableFuture<StableSnapshot> future = new CompletableFuture<>();
+        InProgressSnapshot snapshot = new InProgressSnapshot(future);
+        int threadCount = 4;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    if (threadId == 0) {
+                        snapshot.cancel();
+                    } else {
+                        try {
+                            snapshot.await(Duration.ofMillis(100));
+                        } catch (TimeoutException | RuntimeException | java.util.concurrent.ExecutionException e) {
+                            // Expected: either timeout or cancellation
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // Start all threads
+        Assert.assertTrue(doneLatch.await(2, TimeUnit.SECONDS), "Concurrent operations timed out");
+        executor.shutdown();
+    }
+
+    // ---- Helpers ----
+
+    private StableSnapshot createMockStableSnapshot() {
+        return new StableSnapshot(
+                mock(PackageCompilation.class),
+                mock(SemanticModel.class),
+                Map.of(),
+                new ContentVersion(1)
+        );
+    }
+}

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotTest.java
@@ -20,496 +20,140 @@ package org.ballerinalang.langserver.workspace.compilerengine;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
 import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for dual-snapshot types: SyntaxSnapshot, StableSnapshot, InProgressSnapshot.
+ * Tests for the ADR-042 dual-snapshot contracts.
  *
  * @since 1.7.0
  */
 public class DualSnapshotTest {
 
-    // ---- SyntaxSnapshot sealed interface ----
-
     @Test
-    public void syntaxSnapshot_permitsStableAndInProgress() {
-        // Verify both types implement SyntaxSnapshot
-        SyntaxSnapshot stable = createMockStableSnapshot();
-        SyntaxSnapshot inProgress = createMockInProgressSnapshot();
-        
-        Assert.assertNotNull(stable);
-        Assert.assertNotNull(inProgress);
-        Assert.assertTrue(stable instanceof StableSnapshot);
-        Assert.assertTrue(inProgress instanceof InProgressSnapshot);
+    public void snapshotView_exposesSyntaxTreeAndContentVersion() throws NoSuchMethodException {
+        Method syntaxTree = SnapshotView.class.getMethod("syntaxTree", DocumentId.class);
+        Method contentVersion = SnapshotView.class.getMethod("contentVersion");
+
+        Assert.assertEquals(syntaxTree.getReturnType(), SyntaxTree.class);
+        Assert.assertEquals(contentVersion.getReturnType(), ContentVersion.class);
     }
 
     @Test
-    public void syntaxSnapshot_isSealed() {
-        // Verify SyntaxSnapshot is sealed by checking permits clause via reflection
-        Class<?>[] permits = SyntaxSnapshot.class.getPermittedSubclasses();
-        Assert.assertEquals(permits.length, 2, "SyntaxSnapshot should permit two subclasses");
-        // Verify both StableSnapshot and InProgressSnapshot are permitted
-        boolean hasStable = false;
-        boolean hasInProgress = false;
-        for (Class<?> cls : permits) {
-            if (cls == StableSnapshot.class) hasStable = true;
-            if (cls == InProgressSnapshot.class) hasInProgress = true;
-        }
-        Assert.assertTrue(hasStable, "SyntaxSnapshot should permit StableSnapshot");
-        Assert.assertTrue(hasInProgress, "SyntaxSnapshot should permit InProgressSnapshot");
+    public void stableSnapshot_extendsSnapshotView() {
+        Assert.assertTrue(SnapshotView.class.isAssignableFrom(StableSnapshot.class));
     }
 
-    // ---- StableSnapshot ----
+    @Test
+    public void stableSnapshot_exposesSynchronousSemanticAccess() throws NoSuchMethodException {
+        Method semanticModel = StableSnapshot.class.getMethod("semanticModel", ModuleId.class);
+        Method compilation = StableSnapshot.class.getMethod("compilation");
+
+        Assert.assertEquals(semanticModel.getReturnType(), SemanticModel.class);
+        Assert.assertEquals(compilation.getReturnType(), PackageCompilation.class);
+    }
 
     @Test
-    public void stableSnapshot_syntaxTreeReturnsCorrectTree() {
+    public void inProgressSnapshot_extendsSnapshotView() {
+        Assert.assertTrue(SnapshotView.class.isAssignableFrom(InProgressSnapshot.class));
+    }
+
+    @Test
+    public void inProgressSnapshot_exposesAsyncSemanticAccess() throws NoSuchMethodException {
+        Method semanticModel = InProgressSnapshot.class.getMethod("semanticModel", ModuleId.class,
+                CancelChecker.class);
+        Method compilation = InProgressSnapshot.class.getMethod("compilation", CancelChecker.class);
+
+        Assert.assertEquals(semanticModel.getReturnType(), CompletableFuture.class);
+        Assert.assertEquals(compilation.getReturnType(), CompletableFuture.class);
+    }
+
+    @Test
+    public void stableSnapshot_stubProvidesImmediateSyntaxAndCompilation() {
+        DocumentId documentId = mock(DocumentId.class);
         ModuleId moduleId = mock(ModuleId.class);
         SyntaxTree syntaxTree = mock(SyntaxTree.class);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
-
-        StableSnapshot snapshot = new StableSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                syntaxTrees,
-                new ContentVersion(1)
-        );
-
-        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
-    }
-
-    @Test
-    public void stableSnapshot_syntaxTreeReturnsNullForUnknownModule() {
-        ModuleId knownModule = mock(ModuleId.class);
-        ModuleId unknownModule = mock(ModuleId.class);
-        SyntaxTree syntaxTree = mock(SyntaxTree.class);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(knownModule, syntaxTree);
-
-        StableSnapshot snapshot = new StableSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                syntaxTrees,
-                new ContentVersion(1)
-        );
-
-        Assert.assertNull(snapshot.syntaxTree(unknownModule));
-    }
-
-    @Test
-    public void stableSnapshot_semanticModelReturnsCorrectModel() {
         SemanticModel semanticModel = mock(SemanticModel.class);
-
-        StableSnapshot snapshot = new StableSnapshot(
-                mock(PackageCompilation.class),
-                semanticModel,
-                Map.of(),
-                new ContentVersion(1)
-        );
-
-        Assert.assertSame(snapshot.semanticModel(), semanticModel);
-    }
-
-    @Test
-    public void stableSnapshot_compilationReturnsCorrectResult() {
         PackageCompilation compilation = mock(PackageCompilation.class);
+        ContentVersion contentVersion = new ContentVersion(1);
 
-        StableSnapshot snapshot = new StableSnapshot(
-                compilation,
-                mock(SemanticModel.class),
-                Map.of(),
-                new ContentVersion(1)
-        );
+        StableSnapshot snapshot = new TestStableSnapshot(Map.of(documentId, syntaxTree), contentVersion,
+                Map.of(moduleId, semanticModel), compilation);
 
+        Assert.assertSame(snapshot.syntaxTree(documentId), syntaxTree);
+        Assert.assertSame(snapshot.semanticModel(moduleId), semanticModel);
         Assert.assertSame(snapshot.compilation(), compilation);
+        Assert.assertEquals(snapshot.contentVersion(), contentVersion);
     }
 
     @Test
-    public void stableSnapshot_isImmutableRecord() {
+    public void inProgressSnapshot_stubProvidesImmediateSyntaxAndAsyncResults() throws Exception {
+        DocumentId documentId = mock(DocumentId.class);
         ModuleId moduleId = mock(ModuleId.class);
+        CancelChecker cancelChecker = mock(CancelChecker.class);
         SyntaxTree syntaxTree = mock(SyntaxTree.class);
         SemanticModel semanticModel = mock(SemanticModel.class);
         PackageCompilation compilation = mock(PackageCompilation.class);
-        ContentVersion version = new ContentVersion(1);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
+        ContentVersion contentVersion = new ContentVersion(2);
 
-        StableSnapshot snapshot = new StableSnapshot(
-                compilation,
-                semanticModel,
-                syntaxTrees,
-                version
-        );
+        InProgressSnapshot snapshot = new TestInProgressSnapshot(
+                Map.of(documentId, syntaxTree),
+                contentVersion,
+                CompletableFuture.completedFuture(semanticModel),
+                CompletableFuture.completedFuture(compilation));
 
-        // Verify record accessors
-        Assert.assertSame(snapshot.semanticModel(), semanticModel);
-        Assert.assertSame(snapshot.compilation(), compilation);
-        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
-        Assert.assertEquals(snapshot.contentVersion(), version);
+        Assert.assertSame(snapshot.syntaxTree(documentId), syntaxTree);
+        Assert.assertSame(snapshot.semanticModel(moduleId, cancelChecker).get(), semanticModel);
+        Assert.assertSame(snapshot.compilation(cancelChecker).get(), compilation);
+        Assert.assertEquals(snapshot.contentVersion(), contentVersion);
     }
 
-    @Test
-    public void stableSnapshot_rejectsNullCompilation() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new StableSnapshot(
-                        null,
-                        mock(SemanticModel.class),
-                        Map.of(),
-                        new ContentVersion(1)
-                )
-        );
-    }
+    private record TestStableSnapshot(Map<DocumentId, SyntaxTree> syntaxTrees,
+                                      ContentVersion contentVersion,
+                                      Map<ModuleId, SemanticModel> semanticModels,
+                                      PackageCompilation compilation) implements StableSnapshot {
 
-    @Test
-    public void stableSnapshot_rejectsNullSemanticModel() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new StableSnapshot(
-                        mock(PackageCompilation.class),
-                        null,
-                        Map.of(),
-                        new ContentVersion(1)
-                )
-        );
-    }
-
-    @Test
-    public void stableSnapshot_rejectsNullSyntaxTrees() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new StableSnapshot(
-                        mock(PackageCompilation.class),
-                        mock(SemanticModel.class),
-                        null,
-                        new ContentVersion(1)
-                )
-        );
-    }
-
-    @Test
-    public void stableSnapshot_rejectsNullContentVersion() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new StableSnapshot(
-                        mock(PackageCompilation.class),
-                        mock(SemanticModel.class),
-                        Map.of(),
-                        null
-                )
-        );
-    }
-
-    @Test
-    public void stableSnapshot_equalityByValue() {
-        PackageCompilation compilation = mock(PackageCompilation.class);
-        SemanticModel semanticModel = mock(SemanticModel.class);
-        ContentVersion version = new ContentVersion(1);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of();
-
-        StableSnapshot s1 = new StableSnapshot(
-                compilation,
-                semanticModel,
-                syntaxTrees,
-                version
-        );
-        StableSnapshot s2 = new StableSnapshot(
-                compilation,
-                semanticModel,
-                syntaxTrees,
-                version
-        );
-
-        Assert.assertEquals(s1, s2);
-        Assert.assertEquals(s1.hashCode(), s2.hashCode());
-    }
-
-    @Test
-    public void stableSnapshot_threadSafeAccess() throws InterruptedException {
-        StableSnapshot snapshot = createMockStableSnapshot();
-        int threadCount = 8;
-        CountDownLatch latch = new CountDownLatch(threadCount);
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-        for (int i = 0; i < threadCount; i++) {
-            executor.submit(() -> {
-                try {
-                    // Access snapshot from multiple threads
-                    Assert.assertNotNull(snapshot.semanticModel());
-                    Assert.assertNotNull(snapshot.contentVersion());
-                } finally {
-                    latch.countDown();
-                }
-            });
+        @Override
+        public SyntaxTree syntaxTree(DocumentId docId) {
+            return syntaxTrees.get(docId);
         }
 
-        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS), "Concurrent access timed out");
-        executor.shutdown();
+        @Override
+        public SemanticModel semanticModel(ModuleId moduleId) {
+            return semanticModels.get(moduleId);
+        }
     }
 
-    // ---- InProgressSnapshot ----
+    private record TestInProgressSnapshot(Map<DocumentId, SyntaxTree> syntaxTrees,
+                                          ContentVersion contentVersion,
+                                          CompletableFuture<SemanticModel> semanticFuture,
+                                          CompletableFuture<PackageCompilation> compilationFuture)
+            implements InProgressSnapshot {
 
-    @Test
-    public void inProgressSnapshot_syntaxTreeReturnsCorrectTree() {
-        ModuleId moduleId = mock(ModuleId.class);
-        SyntaxTree syntaxTree = mock(SyntaxTree.class);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                syntaxTrees,
-                new CompletableFuture<>(),
-                new CompletableFuture<>(),
-                new ContentVersion(1)
-        );
-
-        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
-    }
-
-    @Test
-    public void inProgressSnapshot_syntaxTreeReturnsNullForUnknownModule() {
-        ModuleId knownModule = mock(ModuleId.class);
-        ModuleId unknownModule = mock(ModuleId.class);
-        SyntaxTree syntaxTree = mock(SyntaxTree.class);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(knownModule, syntaxTree);
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                syntaxTrees,
-                new CompletableFuture<>(),
-                new CompletableFuture<>(),
-                new ContentVersion(1)
-        );
-
-        Assert.assertNull(snapshot.syntaxTree(unknownModule));
-    }
-
-    @Test
-    public void inProgressSnapshot_syntaxTreeAvailableImmediately() {
-        ModuleId moduleId = mock(ModuleId.class);
-        SyntaxTree syntaxTree = mock(SyntaxTree.class);
-        Map<ModuleId, SyntaxTree> syntaxTrees = Map.of(moduleId, syntaxTree);
-
-        // Create InProgressSnapshot with incomplete futures
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                syntaxTrees,
-                new CompletableFuture<>(),  // Not completed
-                new CompletableFuture<>(),  // Not completed
-                new ContentVersion(1)
-        );
-
-        // Syntax tree should be available even though futures aren't complete
-        Assert.assertSame(snapshot.syntaxTree(moduleId), syntaxTree);
-    }
-
-    @Test
-    public void inProgressSnapshot_semanticModelReturnsFuture() {
-        CompletableFuture<SemanticModel> semanticFuture = new CompletableFuture<>();
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                semanticFuture,
-                new CompletableFuture<>(),
-                new ContentVersion(1)
-        );
-
-        Assert.assertSame(snapshot.semanticModel(), semanticFuture);
-    }
-
-    @Test
-    public void inProgressSnapshot_compilationReturnsFuture() {
-        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                new CompletableFuture<>(),
-                compilationFuture,
-                new ContentVersion(1)
-        );
-
-        Assert.assertSame(snapshot.compilation(), compilationFuture);
-    }
-
-    @Test
-    public void inProgressSnapshot_semanticModelCompletesSuccessfully() throws Exception {
-        SemanticModel expectedModel = mock(SemanticModel.class);
-        CompletableFuture<SemanticModel> semanticFuture = CompletableFuture.completedFuture(expectedModel);
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                semanticFuture,
-                new CompletableFuture<>(),
-                new ContentVersion(1)
-        );
-
-        SemanticModel result = snapshot.semanticModel().get(1, TimeUnit.SECONDS);
-        Assert.assertSame(result, expectedModel);
-    }
-
-    @Test
-    public void inProgressSnapshot_compilationCompletesSuccessfully() throws Exception {
-        PackageCompilation expectedCompilation = mock(PackageCompilation.class);
-        CompletableFuture<PackageCompilation> compilationFuture = CompletableFuture.completedFuture(expectedCompilation);
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                new CompletableFuture<>(),
-                compilationFuture,
-                new ContentVersion(1)
-        );
-
-        PackageCompilation result = snapshot.compilation().get(1, TimeUnit.SECONDS);
-        Assert.assertSame(result, expectedCompilation);
-    }
-
-    @Test
-    public void inProgressSnapshot_cancelCancelsBothFutures() {
-        CompletableFuture<SemanticModel> semanticFuture = new CompletableFuture<>();
-        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                semanticFuture,
-                compilationFuture,
-                new ContentVersion(1)
-        );
-
-        Assert.assertFalse(semanticFuture.isCancelled());
-        Assert.assertFalse(compilationFuture.isCancelled());
-
-        snapshot.cancel();
-
-        Assert.assertTrue(semanticFuture.isCancelled());
-        Assert.assertTrue(compilationFuture.isCancelled());
-    }
-
-    @Test
-    public void inProgressSnapshot_cancelReturnsTrueIfAnyFutureWasCancelled() {
-        // Already completed futures cannot be cancelled
-        CompletableFuture<SemanticModel> semanticFuture = CompletableFuture.completedFuture(mock(SemanticModel.class));
-        CompletableFuture<PackageCompilation> compilationFuture = new CompletableFuture<>();
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                semanticFuture,
-                compilationFuture,
-                new ContentVersion(1)
-        );
-
-        boolean result = snapshot.cancel();
-
-        Assert.assertTrue(result); // One future was cancelled
-        Assert.assertFalse(semanticFuture.isCancelled()); // Already completed
-        Assert.assertTrue(compilationFuture.isCancelled()); // Was cancelled
-    }
-
-    @Test
-    public void inProgressSnapshot_rejectsNullSyntaxTrees() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new InProgressSnapshot(
-                        null,
-                        new CompletableFuture<>(),
-                        new CompletableFuture<>(),
-                        new ContentVersion(1)
-                )
-        );
-    }
-
-    @Test
-    public void inProgressSnapshot_rejectsNullSemanticFuture() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new InProgressSnapshot(
-                        Map.of(),
-                        null,
-                        new CompletableFuture<>(),
-                        new ContentVersion(1)
-                )
-        );
-    }
-
-    @Test
-    public void inProgressSnapshot_rejectsNullCompilationFuture() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new InProgressSnapshot(
-                        Map.of(),
-                        new CompletableFuture<>(),
-                        null,
-                        new ContentVersion(1)
-                )
-        );
-    }
-
-    @Test
-    public void inProgressSnapshot_rejectsNullContentVersion() {
-        Assert.assertThrows(NullPointerException.class, () ->
-                new InProgressSnapshot(
-                        Map.of(),
-                        new CompletableFuture<>(),
-                        new CompletableFuture<>(),
-                        null
-                )
-        );
-    }
-
-    @Test
-    public void inProgressSnapshot_contentVersionReturnsCorrectValue() {
-        ContentVersion version = new ContentVersion(42);
-
-        InProgressSnapshot snapshot = new InProgressSnapshot(
-                Map.of(),
-                new CompletableFuture<>(),
-                new CompletableFuture<>(),
-                version
-        );
-
-        Assert.assertEquals(snapshot.contentVersion(), version);
-    }
-
-    @Test
-    public void inProgressSnapshot_threadSafeAccess() throws InterruptedException {
-        InProgressSnapshot snapshot = createMockInProgressSnapshot();
-        int threadCount = 8;
-        CountDownLatch latch = new CountDownLatch(threadCount);
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-        for (int i = 0; i < threadCount; i++) {
-            executor.submit(() -> {
-                try {
-                    // Access snapshot from multiple threads
-                    Assert.assertNotNull(snapshot.contentVersion());
-                    Assert.assertNotNull(snapshot.semanticModel());
-                    Assert.assertNotNull(snapshot.compilation());
-                } finally {
-                    latch.countDown();
-                }
-            });
+        @Override
+        public SyntaxTree syntaxTree(DocumentId docId) {
+            return syntaxTrees.get(docId);
         }
 
-        Assert.assertTrue(latch.await(5, TimeUnit.SECONDS), "Concurrent access timed out");
-        executor.shutdown();
-    }
+        @Override
+        public CompletableFuture<SemanticModel> semanticModel(ModuleId moduleId, CancelChecker checker) {
+            return semanticFuture;
+        }
 
-    // ---- Helpers ----
-
-    private StableSnapshot createMockStableSnapshot() {
-        return new StableSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                Map.of(),
-                new ContentVersion(1)
-        );
-    }
-
-    private InProgressSnapshot createMockInProgressSnapshot() {
-        return new InProgressSnapshot(
-                Map.of(),
-                new CompletableFuture<>(),
-                new CompletableFuture<>(),
-                new ContentVersion(1)
-        );
+        @Override
+        public CompletableFuture<PackageCompilation> compilation(CancelChecker checker) {
+            return compilationFuture;
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Implement the dual-snapshot access pattern as defined in ADR-042 to provide tiered workspace access for LSP features. This architecture allows features to choose between low-latency syntax-only snapshots and high-freshness semantic snapshots.

## Approach

Implemented three new types in the `compilerengine` package using Java records and sealed interfaces for type-safety and immutability:

- **SyntaxSnapshot**: A sealed interface providing synchronous access to per-module syntax trees.
- **StableSnapshot**: A record implementation of `SyntaxSnapshot` providing synchronous access to both syntax and semantic models from the last successful compilation.
- **InProgressSnapshot**: A record wrapper for a `CompletableFuture<StableSnapshot>`, providing asynchronous access to the current compilation cycle with timeout and cancellation support.

## What Was Fixed / Changed

- Established the type hierarchy for dual-snapshot access (`SyntaxSnapshot` -> `StableSnapshot`).
- Added thread-safe, immutable data structures for holding compilation results.
- Integrated `InProgressSnapshot` with standard Java concurrency primitives (`CompletableFuture`, `TimeoutException`) to support the asynchronous compilation pipeline.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/`

## How Has This Been Tested

Comprehensive unit tests were added in `DualSnapshotTest.java` covering:
- Sealed interface hierarchy and permit verification.
- `StableSnapshot` immutability, thread-safety, and accessor logic.
- `InProgressSnapshot` asynchronous behavior: successful completion, timeout handling, and cancellation propagation.
- Multi-threaded stress tests for concurrent await/cancel operations.

## Remarks & Notes

- These types are foundational and will be used by the `DualSnapshotStore` (T-034) and the pipeline wiring (T-039) in subsequent tasks.
- Used `io.ballerina.projects.ModuleId` from the compiler API to identify modules within snapshots.
