### PR TITLE
Add recovery ladder mode transitions

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/FailureType.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/FailureType.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+/**
+ * Failure outcomes that influence recovery ladder mode selection.
+ *
+ * @since 1.7.0
+ */
+public enum FailureType {
+    RESOLUTION_FAILED,
+    RESOLUTION_SUCCEEDED,
+    EXTERNAL_OVERRIDE
+}

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/RecoveryLadder.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/RecoveryLadder.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
+
+import java.util.Objects;
+
+/**
+ * Stateless strategy for traversing the dependency locking recovery ladder.
+ *
+ * @since 1.7.0
+ */
+public final class RecoveryLadder {
+
+    private RecoveryLadder() {
+    }
+
+    /**
+     * Computes the next locking mode for the given recovery signal.
+     *
+     * @param currentMode current locking mode
+     * @param failureType recovery signal to apply
+     * @return next locking mode after applying the recovery ladder rule
+     * @throws NullPointerException if currentMode or failureType is null
+     */
+    public static LockingMode nextMode(LockingMode currentMode, FailureType failureType) {
+        Objects.requireNonNull(currentMode, "currentMode must not be null");
+        Objects.requireNonNull(failureType, "failureType must not be null");
+
+        return switch (failureType) {
+            case RESOLUTION_FAILED -> escalate(currentMode);
+            case RESOLUTION_SUCCEEDED -> deEscalate(currentMode);
+            case EXTERNAL_OVERRIDE -> currentMode;
+        };
+    }
+
+    private static LockingMode escalate(LockingMode currentMode) {
+        return switch (currentMode) {
+            case SOFT -> LockingMode.MEDIUM;
+            case MEDIUM -> LockingMode.HARD;
+            case HARD, LOCKED -> LockingMode.LOCKED;
+        };
+    }
+
+    private static LockingMode deEscalate(LockingMode currentMode) {
+        return switch (currentMode) {
+            case LOCKED -> LockingMode.HARD;
+            case HARD -> LockingMode.MEDIUM;
+            case MEDIUM, SOFT -> LockingMode.SOFT;
+        };
+    }
+}

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/RecoveryLadderTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/RecoveryLadderTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link RecoveryLadder}.
+ *
+ * @since 1.7.0
+ */
+public class RecoveryLadderTest {
+
+    @DataProvider(name = "resolutionFailureTransitions")
+    public Object[][] resolutionFailureTransitions() {
+        return new Object[][]{
+                {LockingMode.SOFT, LockingMode.MEDIUM},
+                {LockingMode.MEDIUM, LockingMode.HARD},
+                {LockingMode.HARD, LockingMode.LOCKED},
+                {LockingMode.LOCKED, LockingMode.LOCKED}
+        };
+    }
+
+    @DataProvider(name = "resolutionSuccessTransitions")
+    public Object[][] resolutionSuccessTransitions() {
+        return new Object[][]{
+                {LockingMode.SOFT, LockingMode.SOFT},
+                {LockingMode.MEDIUM, LockingMode.SOFT},
+                {LockingMode.HARD, LockingMode.MEDIUM},
+                {LockingMode.LOCKED, LockingMode.HARD}
+        };
+    }
+
+    @DataProvider(name = "externalOverrideTransitions")
+    public Object[][] externalOverrideTransitions() {
+        return new Object[][]{
+                {LockingMode.SOFT},
+                {LockingMode.MEDIUM},
+                {LockingMode.HARD},
+                {LockingMode.LOCKED}
+        };
+    }
+
+    @Test(dataProvider = "resolutionFailureTransitions")
+    public void nextMode_resolutionFailed_escalatesOneStep(LockingMode currentMode, LockingMode expectedMode) {
+        // RED: this test should fail - RecoveryLadder not yet implemented
+        Assert.assertEquals(RecoveryLadder.nextMode(currentMode, FailureType.RESOLUTION_FAILED), expectedMode);
+    }
+
+    @Test(dataProvider = "resolutionSuccessTransitions")
+    public void nextMode_resolutionSucceeded_deEscalatesOneStep(LockingMode currentMode, LockingMode expectedMode) {
+        Assert.assertEquals(RecoveryLadder.nextMode(currentMode, FailureType.RESOLUTION_SUCCEEDED), expectedMode);
+    }
+
+    @Test(dataProvider = "externalOverrideTransitions")
+    public void nextMode_externalOverride_preservesCurrentMode(LockingMode currentMode) {
+        Assert.assertEquals(RecoveryLadder.nextMode(currentMode, FailureType.EXTERNAL_OVERRIDE), currentMode);
+    }
+}


### PR DESCRIPTION
## Purpose

Introduce the recovery ladder strategy used to move dependency locking modes up or down based on resolution outcomes, so pipeline recovery can be driven by a stateless rule instead of controller-owned state.

## Approach

Add a new `FailureType` enum to model recovery signals and implement a static `RecoveryLadder.nextMode(...)` utility in the compiler engine package. Reuse the existing `LockingMode` enum and cover the ladder with focused TestNG data-driven tests for escalation, de-escalation, and external override behavior.

## What Was Fixed / Changed

Add explicit recovery signals for resolution failure, resolution success, and external override. Add deterministic mode transitions from `SOFT -> MEDIUM -> HARD -> LOCKED` on failure and `LOCKED -> HARD -> MEDIUM -> SOFT` on success. Preserve the current mode when the signal indicates an external override.

## Affected Components

`langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine`

`langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine`

## How Has This Been Tested

Run `./gradlew :langserver-core:test --tests org.ballerinalang.langserver.workspace.compilerengine.RecoveryLadderTest` to verify all four locking modes across failure, success, and external override paths.

## Remarks & Notes

No production TODOs or FIXMEs were added. One leftover RED-phase comment remains in `RecoveryLadderTest` documenting the original TDD setup.
