### PR TITLE
Replace PathToRootCache with UriResolver in ProjectServiceImpl

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
@@ -31,12 +31,12 @@ import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.execution.ExecutionServiceImpl;
 import org.ballerinalang.langserver.workspace.execution.GracePeriod;
 import org.ballerinalang.langserver.workspace.observability.WorkspaceTraceLogger;
-import org.ballerinalang.langserver.workspace.workspacemanager.PathToRootCache;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectLoader;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceImpl;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
+import org.ballerinalang.langserver.workspace.workspacemanager.UriResolver;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -82,7 +82,7 @@ public final class WiringConfiguration implements AutoCloseable {
         // 2. ProjectService (subscribes to DS-E1, DS-E3, CE-E2, CE-E5;
         //    internally creates LockingModeController which subscribes to CE-E6, CE-E4)
         this.projectService = new ProjectServiceImpl(
-                builder.projectRegistry, builder.pathToRootCache, eventBus, builder.projectLoader);
+                builder.projectRegistry, builder.uriResolver, eventBus, builder.projectLoader);
 
         // 3. CompilationService (subscribes to WM-E1, WM-E2, WM-E4, DS-E2, DS-E4)
         this.compilationService = new CompilationServiceImpl(
@@ -277,7 +277,7 @@ public final class WiringConfiguration implements AutoCloseable {
         private SnapshotStore snapshotStore;
         private CompilationPipeline.CompilationAction compilationAction;
         private ProjectRegistry projectRegistry;
-        private PathToRootCache pathToRootCache;
+        private UriResolver uriResolver;
         private ProjectLoader projectLoader;
         private GracePeriod gracePeriod;
         private int maxActiveProcesses = 5;
@@ -312,8 +312,8 @@ public final class WiringConfiguration implements AutoCloseable {
             return this;
         }
 
-        public Builder pathToRootCache(PathToRootCache pathToRootCache) {
-            this.pathToRootCache = pathToRootCache;
+        public Builder uriResolver(UriResolver uriResolver) {
+            this.uriResolver = uriResolver;
             return this;
         }
 
@@ -339,7 +339,7 @@ public final class WiringConfiguration implements AutoCloseable {
             Objects.requireNonNull(snapshotStore, "snapshotStore must not be null");
             Objects.requireNonNull(compilationAction, "compilationAction must not be null");
             Objects.requireNonNull(projectRegistry, "projectRegistry must not be null");
-            Objects.requireNonNull(pathToRootCache, "pathToRootCache must not be null");
+            Objects.requireNonNull(uriResolver, "uriResolver must not be null");
             Objects.requireNonNull(projectLoader, "projectLoader must not be null");
             Objects.requireNonNull(gracePeriod, "gracePeriod must not be null");
             return new WiringConfiguration(this);

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
@@ -37,9 +37,9 @@ import org.ballerinalang.langserver.workspace.execution.GracePeriod;
 import org.ballerinalang.langserver.workspace.lspgateway.ClientSession;
 import org.ballerinalang.langserver.workspace.lspgateway.WorkspaceManagerFacadeImpl;
 import org.ballerinalang.langserver.workspace.workspacemanager.MemoryBudget;
-import org.ballerinalang.langserver.workspace.workspacemanager.PathToRootCache;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceImpl;
+import org.ballerinalang.langserver.workspace.workspacemanager.UriResolver;
 import org.eclipse.lsp4j.ClientCapabilities;
 
 import java.nio.file.Path;
@@ -74,7 +74,7 @@ public final class WorkspaceManagerFacadeFactory {
         VirtualFileSystem vfs = new VirtualFileSystem();
         SnapshotStore snapshotStore = new SnapshotStore(100);
         ProjectRegistry projectRegistry = new ProjectRegistry(MemoryBudget.ofMb(512));
-        PathToRootCache pathToRootCache = new PathToRootCache();
+        UriResolver uriResolver = new UriResolver();
         GracePeriod gracePeriod = GracePeriod.ofMillis(2000);
 
         // Holder to break the circular reference: compilationAction -> projectService
@@ -122,7 +122,7 @@ public final class WorkspaceManagerFacadeFactory {
                 .snapshotStore(snapshotStore)
                 .compilationAction(compilationAction)
                 .projectRegistry(projectRegistry)
-                .pathToRootCache(pathToRootCache)
+                .uriResolver(uriResolver)
                 .projectLoader((root, kind) ->
                         BallerinaCompilerApi.getInstance().loadProject(root.path(), buildOptions))
                 .gracePeriod(gracePeriod)

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
@@ -22,12 +22,14 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
@@ -47,7 +49,7 @@ import java.util.concurrent.ExecutionException;
  * <ul>
  *   <li>Project lifecycle via {@link ProjectRegistry}</li>
  *   <li>Ballerina project caching via internal {@link ConcurrentHashMap}</li>
- *   <li>File-to-root mapping via {@link PathToRootCache}</li>
+ *   <li>URI resolution via {@link UriResolver} (lock-free trie cache per ADR-048)</li>
  *   <li>Heap pressure monitoring via {@link HeapPressureListener}</li>
  *   <li>Domain event publishing and subscription via {@link EventSyncPubSubHolder}</li>
  * </ul>
@@ -55,7 +57,6 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Wiring order is critical (ADR-009):
  * <ol>
- *   <li>Register PathToRootCache as ProjectRegistry listener</li>
  *   <li>Register self as ProjectRegistry listener for eviction/batch events</li>
  *   <li>Create and start HeapPressureListener</li>
  *   <li>Subscribe to incoming domain events</li>
@@ -70,19 +71,18 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private static final int DEFAULT_HEAP_MB = 64;
 
     private final ProjectRegistry registry;
-    private final PathToRootCache pathToRootCache;
+    private final UriResolver uriResolver;
     private final EventSyncPubSubHolder eventBus;
     private final ProjectLoader loader;
     private final ConcurrentHashMap<SourceRoot, Project> ballerinaProjects;
     private final LockingModeController lockingModeController;
     private final HeapPressureListener heapListener;
 
-    /**
+/**
      * Constructs a project service with full wiring of dependencies.
      *
      * <p>Critical wiring order per ADR-009:
      * <ol>
-     *   <li>Wire PathToRootCache as registry listener</li>
      *   <li>Wire self as registry listener</li>
      *   <li>Create and start HeapPressureListener</li>
      *   <li>Subscribe to domain events</li>
@@ -91,36 +91,33 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
      * </p>
      *
      * @param registry project registry; must not be null
-     * @param pathToRootCache path-to-root cache; must not be null
+     * @param uriResolver URI resolver for lock-free path resolution; must not be null
      * @param eventBus event bus; must not be null
      * @param loader Ballerina project loader; must not be null
      * @throws NullPointerException if any argument is null
      */
-    public ProjectServiceImpl(ProjectRegistry registry, PathToRootCache pathToRootCache,
-                             EventSyncPubSubHolder eventBus, ProjectLoader loader) {
+    public ProjectServiceImpl(ProjectRegistry registry, UriResolver uriResolver,
+                              EventSyncPubSubHolder eventBus, ProjectLoader loader) {
         Objects.requireNonNull(registry, "registry must not be null");
-        Objects.requireNonNull(pathToRootCache, "pathToRootCache must not be null");
+        Objects.requireNonNull(uriResolver, "uriResolver must not be null");
         Objects.requireNonNull(eventBus, "eventBus must not be null");
         Objects.requireNonNull(loader, "loader must not be null");
 
         this.registry = registry;
-        this.pathToRootCache = pathToRootCache;
+        this.uriResolver = uriResolver;
         this.eventBus = eventBus;
         this.loader = loader;
         this.ballerinaProjects = new ConcurrentHashMap<>();
         this.lockingModeController = new LockingModeController(eventBus);
 
-        // 1. Wire PathToRootCache as registry listener (T-008 DO NOT constraint resolved here)
-        registry.addListener(pathToRootCache);
-
-        // 2. Wire self as registry listener for eviction and batch events
+        // 1. Wire self as registry listener for eviction and batch events
         registry.addListener(this);
 
-        // 3. Create and start HeapPressureListener
+        // 2. Create and start HeapPressureListener
         this.heapListener = new HeapPressureListener(0.75, registry::evictBackgroundProjects);
         heapListener.start();
 
-        // 4. Subscribe to incoming domain events
+        // 3. Subscribe to incoming domain events
         eventBus.subscribe("wm-document-opened", SubscriberTier.CRITICAL,
                 Set.of(EventKind.DOCUMENT_OPENED), this::onDocumentOpened);
         eventBus.subscribe("wm-document-closed", SubscriberTier.CRITICAL,
@@ -130,7 +127,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         eventBus.subscribe("wm-diagnostics-ready", SubscriberTier.CRITICAL,
                 Set.of(EventKind.COMPILER_DIAGNOSTICS_READY), this::onDiagnosticsReady);
 
-        // 5. Default locking mode is already initialized above
+        // 4. Default locking mode is already initialized above
     }
 
     // =========================================================================
@@ -143,13 +140,11 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
 
         Path normalized = path.toAbsolutePath().normalize();
 
-        // Fast path: check if already cached
-        Optional<SourceRoot> cached = pathToRootCache.get(normalized);
-        if (cached.isPresent()) {
-            Project bp = ballerinaProjects.get(cached.get());
-            if (bp != null) {
-                return bp;
-            }
+        // Fast path: check if already cached in UriResolver
+        DocumentUri docUri = toFileUri(normalized);
+        Optional<ResolvedEntry> cached = uriResolver.resolve(docUri);
+        if (cached.isPresent() && cached.get() instanceof ResolvedEntry.ProjectEntry projectEntry) {
+            return projectEntry.project();
         }
 
         // Slow path: resolve root, get-or-create WM project (ADR-019 mandate 2)
@@ -169,7 +164,8 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
                 publishWm(EventKind.WORKSPACE_PROJECT_REGISTERED, root);
             }
 
-            pathToRootCache.put(normalized, root);
+            // Register in UriResolver for fast-path resolution
+            uriResolver.register(docUri, new ResolvedEntry.ProjectEntry(prev != null ? prev : bp));
             return prev != null ? prev : bp;
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to load project for " + root, e);
@@ -241,7 +237,9 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
                         new org.ballerinalang.langserver.workspace.workspacemanager.Project(
                                 root, kind, HeapEstimate.ofMb(DEFAULT_HEAP_MB)));
 
-                pathToRootCache.put(normalized, root);
+                // Register in UriResolver for fast-path resolution
+                DocumentUri docUri = toFileUri(normalized);
+                uriResolver.register(docUri, new ResolvedEntry.ProjectEntry(bp));
             } catch (Exception e) {
                 // Log and continue with next folder
                 System.err.println("Warning: Failed to register workspace project at " + root + ": " + e);
@@ -267,12 +265,14 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
             case PROJECT_REMOVED -> {
                 if (event.affectedRoot() != null) {
                     ballerinaProjects.remove(event.affectedRoot());
+                    // Evict the entire subtree from UriResolver
+                    uriResolver.evictSubtree(event.affectedRoot());
                     publishWm(EventKind.WORKSPACE_PROJECT_EVICTED, event.affectedRoot());
                 }
             }
             case BATCH_UPDATE -> publishWmNoRoot(EventKind.WORKSPACE_BATCH_PROJECTS_REGISTERED);
             case PROJECT_ADDED -> {
-                // PathToRootCache handles invalidation; no WM action needed here
+                // UriResolver updates happen during loadOrCreate; no action needed here
             }
         }
     }
@@ -283,26 +283,42 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
 
     private void onDocumentOpened(DomainEvent event) {
         Path path = parsePath(event.coalesceScope());
-        pathToRootCache.get(path).flatMap(registry::get).ifPresent(project -> {
-            ProjectTier before = project.openDocumentCount().tier();
-            project.openDocumentCount().increment();
-            ProjectTier after = project.openDocumentCount().tier();
-            if (before != after) {
-                publishWm(EventKind.WORKSPACE_PROJECT_TIER_CHANGED, project.sourceRoot());
-            }
-        });
+        DocumentUri docUri = toFileUri(path);
+        uriResolver.resolve(docUri)
+                .filter(ResolvedEntry.ProjectEntry.class::isInstance)
+                .map(ResolvedEntry.ProjectEntry.class::cast)
+                .map(ResolvedEntry.ProjectEntry::project)
+                .ifPresent(project -> {
+                    // Find the WM project for tier tracking
+                    registry.get(new SourceRoot(path)).ifPresent(wmProject -> {
+                        ProjectTier before = wmProject.openDocumentCount().tier();
+                        wmProject.openDocumentCount().increment();
+                        ProjectTier after = wmProject.openDocumentCount().tier();
+                        if (before != after) {
+                            publishWm(EventKind.WORKSPACE_PROJECT_TIER_CHANGED, wmProject.sourceRoot());
+                        }
+                    });
+                });
     }
 
     private void onDocumentClosed(DomainEvent event) {
         Path path = parsePath(event.coalesceScope());
-        pathToRootCache.get(path).flatMap(registry::get).ifPresent(project -> {
-            ProjectTier before = project.openDocumentCount().tier();
-            project.openDocumentCount().decrement();
-            ProjectTier after = project.openDocumentCount().tier();
-            if (before != after) {
-                publishWm(EventKind.WORKSPACE_PROJECT_TIER_CHANGED, project.sourceRoot());
-            }
-        });
+        DocumentUri docUri = toFileUri(path);
+        uriResolver.resolve(docUri)
+                .filter(ResolvedEntry.ProjectEntry.class::isInstance)
+                .map(ResolvedEntry.ProjectEntry.class::cast)
+                .map(ResolvedEntry.ProjectEntry::project)
+                .ifPresent(project -> {
+                    // Find the WM project for tier tracking
+                    registry.get(new SourceRoot(path)).ifPresent(wmProject -> {
+                        ProjectTier before = wmProject.openDocumentCount().tier();
+                        wmProject.openDocumentCount().decrement();
+                        ProjectTier after = wmProject.openDocumentCount().tier();
+                        if (before != after) {
+                            publishWm(EventKind.WORKSPACE_PROJECT_TIER_CHANGED, wmProject.sourceRoot());
+                        }
+                    });
+                });
     }
 
     private void onCompilationFailed(DomainEvent event) {
@@ -370,9 +386,14 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     public void evictProject(Path filePath) {
         Path normalized = filePath.toAbsolutePath().normalize();
         try {
-            Optional<SourceRoot> cached = pathToRootCache.get(normalized);
-            SourceRoot root = cached.orElseGet(() -> resolveSourceRoot(normalized));
+            DocumentUri docUri = toFileUri(normalized);
+            SourceRoot root = uriResolver.resolve(docUri)
+                    .filter(ResolvedEntry.ProjectEntry.class::isInstance)
+                    .map(ResolvedEntry.ProjectEntry.class::cast)
+                    .map(e -> findSourceRoot(e.project()))
+                    .orElseGet(() -> resolveSourceRoot(normalized));
             ballerinaProjects.remove(root);
+            uriResolver.evictSubtree(root);
         } catch (Exception ignored) {
             // Path not resolvable — no-op.
         }
@@ -387,18 +408,20 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     public void removeDocumentFromProject(Path filePath) {
         Path normalized = filePath.toAbsolutePath().normalize();
         try {
-            Optional<SourceRoot> cached = pathToRootCache.get(normalized);
+            DocumentUri docUri = toFileUri(normalized);
+            Optional<ResolvedEntry> cached = uriResolver.resolve(docUri);
             if (cached.isEmpty()) {
                 return;
             }
-            Project project = ballerinaProjects.get(cached.get());
-            if (project == null) {
+            if (!(cached.get() instanceof ResolvedEntry.ProjectEntry projectEntry)) {
                 return;
             }
+            Project project = projectEntry.project();
             DocumentId docId = project.documentId(normalized);
             Document document = project.currentPackage().module(docId.moduleId()).document(docId);
             Project updated = document.module().modify().removeDocument(docId).apply().project();
-            ballerinaProjects.put(cached.get(), updated);
+            // Update the resolver with the new project
+            uriResolver.register(docUri, new ResolvedEntry.ProjectEntry(updated));
         } catch (Exception ignored) {
             // Document may not be in project or project not loaded — skip.
         }
@@ -532,5 +555,32 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private void publishWmNoRoot(EventKind kind) {
         eventBus.publish(new DomainEvent(Instant.now(), "workspace-manager", kind,
                 "workspace-manager"));
+    }
+
+    /**
+     * Converts a Path to a DocumentUri.FileUri.
+     *
+     * @param path the file path
+     * @return a DocumentUri for the path
+     */
+    private static DocumentUri toFileUri(Path path) {
+        URI uri = path.toUri();
+        return new DocumentUri.FileUri(uri);
+    }
+
+    /**
+     * Finds the SourceRoot for a Ballerina project by searching in ballerinaProjects.
+     * This is used when we have a Project but need to find its corresponding SourceRoot.
+     *
+     * @param project the Ballerina project
+     * @return the SourceRoot if found, or null if not found
+     */
+    private SourceRoot findSourceRoot(Project project) {
+        for (Map.Entry<SourceRoot, Project> entry : ballerinaProjects.entrySet()) {
+            if (entry.getValue() == project) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WiringConfigurationTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WiringConfigurationTest.java
@@ -32,11 +32,11 @@ import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.execution.GracePeriod;
 import org.ballerinalang.langserver.workspace.workspacemanager.HeapEstimate;
 import org.ballerinalang.langserver.workspace.workspacemanager.MemoryBudget;
-import org.ballerinalang.langserver.workspace.workspacemanager.PathToRootCache;
 import org.ballerinalang.langserver.workspace.workspacemanager.Project;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
+import org.ballerinalang.langserver.workspace.workspacemanager.UriResolver;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -93,7 +93,7 @@ public class WiringConfigurationTest {
                 .snapshotStore(new SnapshotStore(10))
                 .compilationAction(task -> mockSnapshot)
                 .projectRegistry(new ProjectRegistry(MemoryBudget.ofMb(256)))
-                .pathToRootCache(new PathToRootCache())
+                .uriResolver(new UriResolver())
                 .projectLoader((root, kind) -> mock(io.ballerina.projects.Project.class))
                 .gracePeriod(GracePeriod.ofMillis(1000))
                 .maxActiveProcesses(5)

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.langserver.workspace.workspacemanager;
 
 import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
@@ -30,6 +31,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -52,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 public class ProjectServiceTest {
 
     private ProjectRegistry registry;
-    private PathToRootCache pathToRootCache;
+    private UriResolver uriResolver;
     private EventSyncPubSubHolder eventBus;
     private ProjectServiceImpl service;
     private Path tempDir;
@@ -66,7 +68,7 @@ public class ProjectServiceTest {
         Files.write(tempDir.resolve("Ballerina.toml"), new byte[0]);
 
         registry = new ProjectRegistry(MemoryBudget.ofMb(1024)); // 1GB budget
-        pathToRootCache = new PathToRootCache();
+        uriResolver = new UriResolver();
         eventBus = new EventSyncPubSubHolder();
         publishedEvents = new CopyOnWriteArrayList<>();
         cancelChecker = () -> {}; // Non-cancelling checker for tests
@@ -79,7 +81,7 @@ public class ProjectServiceTest {
                 publishedEvents::add);
 
         ProjectLoader loader = (root, kind) -> mockBallerinaProject(root, kind);
-        service = new ProjectServiceImpl(registry, pathToRootCache, eventBus, loader);
+        service = new ProjectServiceImpl(registry, uriResolver, eventBus, loader);
     }
 
     @AfterMethod
@@ -94,20 +96,17 @@ public class ProjectServiceTest {
     // =========================================================================
 
     @Test(groups = "wiring")
-    public void wiring_pathToRootCacheIsRegisteredAsListener() {
-        // PathToRootCache should be registered during construction
-        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
-        org.ballerinalang.langserver.workspace.workspacemanager.Project project =
-                new org.ballerinalang.langserver.workspace.workspacemanager.Project(
-                        root, org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind.SINGLE_FILE,
-                        HeapEstimate.ofMb(64));
+    public void wiring_uriResolverIsUsedForResolution() throws Exception {
+        // After loadOrCreate, the URI should be resolvable via UriResolver
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
 
-        // Register a project
-        registry.register(root, project);
-
-        // PathToRootCache should have invalidated its entry for this root
-        Optional<SourceRoot> cached = pathToRootCache.get(root.path());
-        Assert.assertTrue(cached.isEmpty(), "PathToRootCache should have invalidated the entry");
+        // The project path should be registered in UriResolver
+        DocumentUri docUri = new DocumentUri.FileUri(projectPath.toUri());
+        Optional<ResolvedEntry> resolved = uriResolver.resolve(docUri);
+        Assert.assertTrue(resolved.isPresent(), "Path should be resolvable via UriResolver");
+        Assert.assertTrue(resolved.get() instanceof ResolvedEntry.ProjectEntry,
+                "Resolved entry should be a ProjectEntry");
     }
 
     @Test(groups = "wiring")
@@ -224,13 +223,14 @@ public class ProjectServiceTest {
     }
 
     @Test(groups = "load-or-create")
-    public void loadOrCreate_cachesPathInPathToRootCache() throws Exception {
+    public void loadOrCreate_cachesPathInUriResolver() throws Exception {
         Path projectPath = tempDir.toAbsolutePath().normalize();
 
         service.loadOrCreate(projectPath, cancelChecker);
 
-        Optional<SourceRoot> cached = pathToRootCache.get(projectPath);
-        Assert.assertTrue(cached.isPresent(), "Path should be cached in PathToRootCache");
+        DocumentUri docUri = new DocumentUri.FileUri(projectPath.toUri());
+        Optional<ResolvedEntry> resolved = uriResolver.resolve(docUri);
+        Assert.assertTrue(resolved.isPresent(), "Path should be resolvable via UriResolver");
     }
 
     @Test(groups = "load-or-create")
@@ -368,41 +368,47 @@ public class ProjectServiceTest {
     }
 
     // =========================================================================
-    // PathToRootCache Invalidation Tests
+    // UriResolver Eviction Tests
     // =========================================================================
 
     @Test(groups = "cache-invalidation")
-    public void cacheInvalidation_projectAddedInvalidatesEntry() {
-        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
-        pathToRootCache.put(root.path(), root);
+    public void cacheInvalidation_projectRemovedEvictsFromUriResolver() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+        
+        // Verify project is registered in UriResolver
+        DocumentUri docUri = new DocumentUri.FileUri(projectPath.toUri());
+        Assert.assertTrue(uriResolver.resolve(docUri).isPresent(), 
+                "Project should be registered in UriResolver");
 
-        org.ballerinalang.langserver.workspace.workspacemanager.Project project =
-                new org.ballerinalang.langserver.workspace.workspacemanager.Project(
-                        root, org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind.SINGLE_FILE,
-                        HeapEstimate.ofMb(64));
+        // Remove the project
+        SourceRoot root = new SourceRoot(projectPath);
+        registry.remove(root);
 
-        registry.register(root, project);
-
-        Optional<SourceRoot> cached = pathToRootCache.get(root.path());
-        Assert.assertTrue(cached.isEmpty(), "PathToRootCache should invalidate on PROJECT_ADDED");
+        // Verify subtree was evicted from UriResolver
+        Assert.assertTrue(uriResolver.resolve(docUri).isEmpty(), 
+                "Project subtree should be evicted from UriResolver after removal");
     }
 
     @Test(groups = "cache-invalidation")
-    public void cacheInvalidation_projectRemovedInvalidatesEntry() {
-        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
-        pathToRootCache.put(root.path(), root);
+    public void cacheInvalidation_subtreeEvictionRemovesAllChildPaths() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+        
+        // Verify project is registered
+        DocumentUri projectUri = new DocumentUri.FileUri(projectPath.toUri());
+        Assert.assertTrue(uriResolver.resolve(projectUri).isPresent(), 
+                "Project should be registered in UriResolver");
 
-        org.ballerinalang.langserver.workspace.workspacemanager.Project project =
-                new org.ballerinalang.langserver.workspace.workspacemanager.Project(
-                        root, org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind.SINGLE_FILE,
-                        HeapEstimate.ofMb(64));
-        registry.register(root, project);
-        pathToRootCache.put(root.path(), root); // Re-cache after register
-
+        // Remove the project (triggers subtree eviction)
+        SourceRoot root = new SourceRoot(projectPath);
         registry.remove(root);
 
-        Optional<SourceRoot> cached = pathToRootCache.get(root.path());
-        Assert.assertTrue(cached.isEmpty(), "PathToRootCache should invalidate on PROJECT_REMOVED");
+        // Verify all paths under the project are also evicted
+        Path childPath = projectPath.resolve("modules/test.bal");
+        DocumentUri childUri = new DocumentUri.FileUri(childPath.toUri());
+        Assert.assertTrue(uriResolver.resolve(childUri).isEmpty(), 
+                "Child paths should be evicted when project subtree is removed");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Purpose

Replace the old path-to-root cache with the new UriResolver so workspace project lookup uses the lock-free trie-based resolution model.

## Approach

Updated ProjectServiceImpl to resolve, register, and evict projects through UriResolver instead of PathToRootCache. Wired the new resolver through WiringConfiguration and WorkspaceManagerFacadeFactory, and adjusted tests to cover UriResolver-backed lookup and subtree eviction.

## What Was Fixed / Changed

- ProjectServiceImpl now resolves project ownership via UriResolver fast-path lookups.
- Project registration now stores URI entries in UriResolver after loading.
- Project eviction now removes resolver subtrees on project removal.
- Workspace wiring now constructs and passes UriResolver instead of PathToRootCache.
- Tests were updated to validate UriResolver registration, lookup, and eviction behavior.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/`
- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/`

## How Has This Been Tested

Compiled `langserver-core` and ran the relevant test suites, including `ProjectServiceTest`, `WiringConfigurationTest`, and `UriResolverTest`.

## Remarks & Notes

UriResolver is now the single source of truth for URI-to-project resolution in this flow. No TODOs or FIXMEs were introduced.
