### PR TITLE
Implement ChangeBuffer per-URI per-layer delta queue

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ChangeBuffer.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ChangeBuffer.java
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.workspacemanager;
+
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.eclipse.lsp4j.FileEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Per-URI, per-layer delta queue for document changes (ADR-047).
+ *
+ * <p>Accumulates pending {@link BufferedChange} events that the ChangeApplier has not yet
+ * processed. Tracks overlay layers per document — the existence of an EDITOR overlay IS the
+ * open/closed signal. Thread-safe: concurrent append/drain on the same URI will not throw or
+ * lose data.
+ *
+ * @since 1.7.0
+ */
+public class ChangeBuffer {
+
+    /**
+     * Per-URI, per-layer pending changes.
+     * Outer key = DocumentUri. Inner key = ChangeLayer. Value = ordered queue of changes.
+     */
+    private final ConcurrentHashMap<DocumentUri,
+            ConcurrentHashMap<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>>> layeredChanges =
+            new ConcurrentHashMap<>();
+
+    /** Pending watcher events for closed documents (no EDITOR layer exists). */
+    private final ConcurrentHashMap<DocumentUri, FileEvent> closedDocChanges = new ConcurrentHashMap<>();
+
+    /** Watcher events for open documents — tracked, action deferred until EDITOR layer is removed. */
+    private final ConcurrentHashMap<DocumentUri, FileEvent> deferredWatcherEvents = new ConcurrentHashMap<>();
+
+    /**
+     * Appends a buffered change to the correct URI + layer queue.
+     *
+     * @param uri    document identity
+     * @param change the change to buffer
+     */
+    public void append(DocumentUri uri, BufferedChange change) {
+        ConcurrentHashMap<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>> layerMap =
+                layeredChanges.computeIfAbsent(uri, k -> new ConcurrentHashMap<>());
+        ConcurrentLinkedQueue<BufferedChange> queue =
+                layerMap.computeIfAbsent(change.layer(), k -> new ConcurrentLinkedQueue<>());
+        queue.add(change);
+    }
+
+    /**
+     * Atomically drains all buffered changes for the given URI and layer, returning them in
+     * insertion order and leaving the queue empty.
+     *
+     * @param uri   document identity
+     * @param layer the overlay layer to drain
+     * @return unmodifiable list of drained changes, empty if none
+     */
+    public List<BufferedChange> drain(DocumentUri uri, ChangeLayer layer) {
+        ConcurrentHashMap<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>> layerMap = layeredChanges.get(uri);
+        if (layerMap == null) {
+            return Collections.emptyList();
+        }
+        AtomicReference<List<BufferedChange>> result = new AtomicReference<>(Collections.emptyList());
+        layerMap.compute(layer, (k, queue) -> {
+            if (queue == null || queue.isEmpty()) {
+                return queue;
+            }
+            result.set(new ArrayList<>(queue));
+            return new ConcurrentLinkedQueue<>();
+        });
+        return result.get();
+    }
+
+    /**
+     * Drains all layers for the given URI, returning changes in layer-priority order:
+     * EDITOR first, then AI, then EXPR.
+     *
+     * @param uri document identity
+     * @return unmodifiable list of drained changes across all layers, empty if none
+     */
+    public List<BufferedChange> drain(DocumentUri uri) {
+        List<BufferedChange> all = new ArrayList<>();
+        for (ChangeLayer layer : ChangeLayer.values()) {
+            all.addAll(drain(uri, layer));
+        }
+        return all;
+    }
+
+    /**
+     * Removes all buffered changes for the given URI across all layers.
+     *
+     * @param uri document identity
+     */
+    public void clear(DocumentUri uri) {
+        layeredChanges.remove(uri);
+    }
+
+    /**
+     * Returns {@code true} if any layer has pending changes for the given URI.
+     *
+     * @param uri document identity
+     * @return {@code true} when at least one change is buffered
+     */
+    public boolean hasChanges(DocumentUri uri) {
+        ConcurrentHashMap<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>> layerMap = layeredChanges.get(uri);
+        if (layerMap == null) {
+            return false;
+        }
+        for (ConcurrentLinkedQueue<BufferedChange> queue : layerMap.values()) {
+            if (!queue.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Routes a file watcher event to the correct map based on whether the document is open.
+     *
+     * <p>Open detection: URI has an EDITOR layer entry (even if the queue is currently empty after
+     * a drain — the key still exists). Routes to {@code deferredWatcherEvents} when open;
+     * routes to {@code closedDocChanges} when closed.
+     *
+     * @param uri   document identity
+     * @param event the file watcher event to route
+     */
+    public void routeWatcherEvent(DocumentUri uri, FileEvent event) {
+        if (isOpen(uri)) {
+            deferredWatcherEvents.put(uri, event);
+        } else {
+            closedDocChanges.put(uri, event);
+        }
+    }
+
+    /**
+     * Atomically returns all pending closed-document watcher events and clears the map.
+     *
+     * @return snapshot of all closed-doc watcher events, empty if none
+     */
+    public Map<DocumentUri, FileEvent> drainClosedDocChanges() {
+        if (closedDocChanges.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<DocumentUri, FileEvent> snapshot = new HashMap<>(closedDocChanges);
+        closedDocChanges.keySet().removeAll(snapshot.keySet());
+        return snapshot;
+    }
+
+    /**
+     * Atomically returns all deferred watcher events (for open documents) and clears the map.
+     *
+     * @return snapshot of all deferred watcher events, empty if none
+     */
+    public Map<DocumentUri, FileEvent> drainDeferredWatcherEvents() {
+        if (deferredWatcherEvents.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<DocumentUri, FileEvent> snapshot = new HashMap<>(deferredWatcherEvents);
+        deferredWatcherEvents.keySet().removeAll(snapshot.keySet());
+        return snapshot;
+    }
+
+    /**
+     * Returns {@code true} if the given URI has an active EDITOR layer (i.e., document is open).
+     * The EDITOR layer key presence — not queue emptiness — determines open state per ADR-047 §6.
+     *
+     * <p>Note: after {@link #drain(DocumentUri, ChangeLayer)} the queue is replaced with an empty
+     * queue (the key remains), so a recently-drained EDITOR layer still counts as open. After
+     * {@link #clear(DocumentUri)} or after the EDITOR layer key is explicitly removed, the document
+     * is considered closed.
+     *
+     * @param uri document identity
+     * @return {@code true} if EDITOR layer key exists for this URI
+     */
+    private boolean isOpen(DocumentUri uri) {
+        ConcurrentHashMap<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>> layerMap = layeredChanges.get(uri);
+        return layerMap != null && layerMap.containsKey(ChangeLayer.EDITOR);
+    }
+}

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ChangeBufferTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ChangeBufferTest.java
@@ -1,0 +1,481 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.workspacemanager;
+
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for ChangeBuffer — per-URI per-layer delta queue.
+ *
+ * @since 1.7.0
+ */
+public class ChangeBufferTest {
+
+    private ChangeBuffer buffer;
+    private DocumentUri mainUri;
+    private DocumentUri utilUri;
+
+    @BeforeMethod
+    public void setUp() {
+        buffer = new ChangeBuffer();
+        mainUri = new DocumentUri.FileUri(URI.create("file:///workspace/main.bal"));
+        utilUri = new DocumentUri.FileUri(URI.create("file:///workspace/util.bal"));
+    }
+
+    private BufferedChange makeChange(String text, ChangeLayer layer, int version) {
+        TextDocumentContentChangeEvent event = new TextDocumentContentChangeEvent(text);
+        return new BufferedChange(event, layer, new ContentVersion(version));
+    }
+
+    // =========================================================================
+    // append() tests
+    // =========================================================================
+
+    @Test
+    public void append_addsToBucketForCorrectUri() {
+        BufferedChange change = makeChange("hello", ChangeLayer.EDITOR, 1);
+        buffer.append(mainUri, change);
+
+        List<BufferedChange> drained = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertEquals(drained.size(), 1);
+        Assert.assertSame(drained.get(0), change);
+    }
+
+    @Test
+    public void append_addsToCorrectLayer() {
+        BufferedChange editorChange = makeChange("editor", ChangeLayer.EDITOR, 1);
+        BufferedChange aiChange = makeChange("ai", ChangeLayer.AI, 1);
+
+        buffer.append(mainUri, editorChange);
+        buffer.append(mainUri, aiChange);
+
+        List<BufferedChange> editorDrained = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        List<BufferedChange> aiDrained = buffer.drain(mainUri, ChangeLayer.AI);
+
+        Assert.assertEquals(editorDrained.size(), 1);
+        Assert.assertSame(editorDrained.get(0), editorChange);
+        Assert.assertEquals(aiDrained.size(), 1);
+        Assert.assertSame(aiDrained.get(0), aiChange);
+    }
+
+    @Test
+    public void append_multipleChangesPreserveInsertionOrder() {
+        BufferedChange c1 = makeChange("first", ChangeLayer.EDITOR, 1);
+        BufferedChange c2 = makeChange("second", ChangeLayer.EDITOR, 2);
+        BufferedChange c3 = makeChange("third", ChangeLayer.EDITOR, 3);
+
+        buffer.append(mainUri, c1);
+        buffer.append(mainUri, c2);
+        buffer.append(mainUri, c3);
+
+        List<BufferedChange> drained = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertEquals(drained.size(), 3);
+        Assert.assertSame(drained.get(0), c1);
+        Assert.assertSame(drained.get(1), c2);
+        Assert.assertSame(drained.get(2), c3);
+    }
+
+    @Test
+    public void append_separateUrisAreIndependent() {
+        BufferedChange mainChange = makeChange("main", ChangeLayer.EDITOR, 1);
+        BufferedChange utilChange = makeChange("util", ChangeLayer.EDITOR, 1);
+
+        buffer.append(mainUri, mainChange);
+        buffer.append(utilUri, utilChange);
+
+        List<BufferedChange> mainDrained = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        List<BufferedChange> utilDrained = buffer.drain(utilUri, ChangeLayer.EDITOR);
+
+        Assert.assertEquals(mainDrained.size(), 1);
+        Assert.assertSame(mainDrained.get(0), mainChange);
+        Assert.assertEquals(utilDrained.size(), 1);
+        Assert.assertSame(utilDrained.get(0), utilChange);
+    }
+
+    // =========================================================================
+    // drain(uri, layer) tests
+    // =========================================================================
+
+    @Test
+    public void drainByLayer_returnsAllChangesInInsertionOrder() {
+        BufferedChange c1 = makeChange("a", ChangeLayer.EDITOR, 1);
+        BufferedChange c2 = makeChange("b", ChangeLayer.EDITOR, 2);
+        buffer.append(mainUri, c1);
+        buffer.append(mainUri, c2);
+
+        List<BufferedChange> result = buffer.drain(mainUri, ChangeLayer.EDITOR);
+
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertSame(result.get(0), c1);
+        Assert.assertSame(result.get(1), c2);
+    }
+
+    @Test
+    public void drainByLayer_clearsQueueAfterDrain() {
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EDITOR, 1));
+
+        buffer.drain(mainUri, ChangeLayer.EDITOR);
+
+        List<BufferedChange> second = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertEquals(second.size(), 0);
+    }
+
+    @Test
+    public void drainByLayer_emptyUriReturnsEmptyList() {
+        List<BufferedChange> result = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 0);
+    }
+
+    @Test
+    public void drainByLayer_emptyLayerReturnsEmptyList() {
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EDITOR, 1));
+
+        List<BufferedChange> result = buffer.drain(mainUri, ChangeLayer.AI);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 0);
+    }
+
+    @Test
+    public void drainByLayer_doesNotAffectOtherLayers() {
+        BufferedChange editorChange = makeChange("e", ChangeLayer.EDITOR, 1);
+        BufferedChange aiChange = makeChange("ai", ChangeLayer.AI, 1);
+        buffer.append(mainUri, editorChange);
+        buffer.append(mainUri, aiChange);
+
+        buffer.drain(mainUri, ChangeLayer.EDITOR);
+
+        List<BufferedChange> aiRemaining = buffer.drain(mainUri, ChangeLayer.AI);
+        Assert.assertEquals(aiRemaining.size(), 1);
+        Assert.assertSame(aiRemaining.get(0), aiChange);
+    }
+
+    // =========================================================================
+    // drain(uri) — all layers in priority order
+    // =========================================================================
+
+    @Test
+    public void drainAllLayers_returnsPriorityOrder_editorFirst() {
+        BufferedChange exprChange = makeChange("expr", ChangeLayer.EXPR, 1);
+        BufferedChange aiChange = makeChange("ai", ChangeLayer.AI, 1);
+        BufferedChange editorChange = makeChange("editor", ChangeLayer.EDITOR, 1);
+
+        // Append in reverse priority order to prove ordering is not insertion-based
+        buffer.append(mainUri, exprChange);
+        buffer.append(mainUri, aiChange);
+        buffer.append(mainUri, editorChange);
+
+        List<BufferedChange> result = buffer.drain(mainUri);
+
+        // EDITOR first, then AI, then EXPR
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.get(0).layer(), ChangeLayer.EDITOR);
+        Assert.assertEquals(result.get(1).layer(), ChangeLayer.AI);
+        Assert.assertEquals(result.get(2).layer(), ChangeLayer.EXPR);
+    }
+
+    @Test
+    public void drainAllLayers_clearsAllLayers() {
+        buffer.append(mainUri, makeChange("e", ChangeLayer.EDITOR, 1));
+        buffer.append(mainUri, makeChange("ai", ChangeLayer.AI, 1));
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EXPR, 1));
+
+        buffer.drain(mainUri);
+
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void drainAllLayers_emptyUriReturnsEmptyList() {
+        List<BufferedChange> result = buffer.drain(mainUri);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 0);
+    }
+
+    @Test
+    public void drainAllLayers_multipleChangesPerLayerPreservedInOrder() {
+        BufferedChange e1 = makeChange("e1", ChangeLayer.EDITOR, 1);
+        BufferedChange e2 = makeChange("e2", ChangeLayer.EDITOR, 2);
+        BufferedChange ai1 = makeChange("ai1", ChangeLayer.AI, 1);
+
+        buffer.append(mainUri, e1);
+        buffer.append(mainUri, e2);
+        buffer.append(mainUri, ai1);
+
+        List<BufferedChange> result = buffer.drain(mainUri);
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertSame(result.get(0), e1);
+        Assert.assertSame(result.get(1), e2);
+        Assert.assertSame(result.get(2), ai1);
+    }
+
+    // =========================================================================
+    // clear(uri) tests
+    // =========================================================================
+
+    @Test
+    public void clear_removesAllDataForUri() {
+        buffer.append(mainUri, makeChange("e", ChangeLayer.EDITOR, 1));
+        buffer.append(mainUri, makeChange("ai", ChangeLayer.AI, 1));
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EXPR, 1));
+
+        buffer.clear(mainUri);
+
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void clear_doesNotAffectOtherUris() {
+        buffer.append(mainUri, makeChange("e", ChangeLayer.EDITOR, 1));
+        buffer.append(utilUri, makeChange("e", ChangeLayer.EDITOR, 1));
+
+        buffer.clear(mainUri);
+
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+        Assert.assertTrue(buffer.hasChanges(utilUri));
+    }
+
+    @Test
+    public void clear_onEmptyUriIsNoOp() {
+        // Should not throw
+        buffer.clear(mainUri);
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    // =========================================================================
+    // hasChanges(uri) tests
+    // =========================================================================
+
+    @Test
+    public void hasChanges_returnsFalseForEmptyUri() {
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void hasChanges_returnsTrueAfterAppend() {
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EDITOR, 1));
+        Assert.assertTrue(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void hasChanges_returnsFalseAfterDrainByLayer() {
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EDITOR, 1));
+        buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void hasChanges_returnsFalseAfterDrainAll() {
+        buffer.append(mainUri, makeChange("e", ChangeLayer.EDITOR, 1));
+        buffer.append(mainUri, makeChange("ai", ChangeLayer.AI, 1));
+        buffer.drain(mainUri);
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void hasChanges_returnsFalseAfterClear() {
+        buffer.append(mainUri, makeChange("x", ChangeLayer.EDITOR, 1));
+        buffer.clear(mainUri);
+        Assert.assertFalse(buffer.hasChanges(mainUri));
+    }
+
+    @Test
+    public void hasChanges_returnsTrueWhenOnlyAiLayerHasChanges() {
+        buffer.append(mainUri, makeChange("ai", ChangeLayer.AI, 1));
+        Assert.assertTrue(buffer.hasChanges(mainUri));
+    }
+
+    // =========================================================================
+    // routeWatcherEvent() tests
+    // =========================================================================
+
+    @Test
+    public void routeWatcherEvent_noEditorLayer_routesToClosedDocChanges() {
+        FileEvent event = new FileEvent("file:///workspace/main.bal", FileChangeType.Changed);
+        buffer.routeWatcherEvent(mainUri, event);
+
+        Map<DocumentUri, FileEvent> closedChanges = buffer.drainClosedDocChanges();
+        Assert.assertTrue(closedChanges.containsKey(mainUri));
+        Assert.assertSame(closedChanges.get(mainUri), event);
+    }
+
+    @Test
+    public void routeWatcherEvent_withEditorLayer_routesToDeferredWatcherEvents() {
+        buffer.append(mainUri, makeChange("open", ChangeLayer.EDITOR, 1));
+
+        FileEvent event = new FileEvent("file:///workspace/main.bal", FileChangeType.Changed);
+        buffer.routeWatcherEvent(mainUri, event);
+
+        // Should NOT be in closedDocChanges
+        Map<DocumentUri, FileEvent> closedChanges = buffer.drainClosedDocChanges();
+        Assert.assertFalse(closedChanges.containsKey(mainUri));
+
+        // Should be in deferredWatcherEvents
+        Map<DocumentUri, FileEvent> deferred = buffer.drainDeferredWatcherEvents();
+        Assert.assertTrue(deferred.containsKey(mainUri));
+        Assert.assertSame(deferred.get(mainUri), event);
+    }
+
+    @Test
+    public void routeWatcherEvent_afterDrainEditorLayer_stillConsideredOpen() {
+        // Drain empties the EDITOR queue but preserves the key — document remains open per ADR-047 §6
+        buffer.append(mainUri, makeChange("open", ChangeLayer.EDITOR, 1));
+        buffer.drain(mainUri, ChangeLayer.EDITOR); // EDITOR key persists, queue is emptied
+
+        FileEvent event = new FileEvent("file:///workspace/main.bal", FileChangeType.Changed);
+        buffer.routeWatcherEvent(mainUri, event);
+
+        // EDITOR key still present => document is open => event is deferred, not closed
+        Map<DocumentUri, FileEvent> closedChanges = buffer.drainClosedDocChanges();
+        Assert.assertFalse(closedChanges.containsKey(mainUri), "Event should NOT be in closedDocChanges");
+
+        Map<DocumentUri, FileEvent> deferred = buffer.drainDeferredWatcherEvents();
+        Assert.assertTrue(deferred.containsKey(mainUri), "Event should be in deferredWatcherEvents");
+    }
+
+    // =========================================================================
+    // drainClosedDocChanges() tests
+    // =========================================================================
+
+    @Test
+    public void drainClosedDocChanges_returnsAllAndClears() {
+        FileEvent e1 = new FileEvent("file:///workspace/main.bal", FileChangeType.Changed);
+        FileEvent e2 = new FileEvent("file:///workspace/util.bal", FileChangeType.Created);
+
+        buffer.routeWatcherEvent(mainUri, e1);
+        buffer.routeWatcherEvent(utilUri, e2);
+
+        Map<DocumentUri, FileEvent> result = buffer.drainClosedDocChanges();
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertSame(result.get(mainUri), e1);
+        Assert.assertSame(result.get(utilUri), e2);
+
+        // Should be empty after drain
+        Map<DocumentUri, FileEvent> second = buffer.drainClosedDocChanges();
+        Assert.assertEquals(second.size(), 0);
+    }
+
+    @Test
+    public void drainClosedDocChanges_emptyReturnsEmptyMap() {
+        Map<DocumentUri, FileEvent> result = buffer.drainClosedDocChanges();
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 0);
+    }
+
+    // =========================================================================
+    // Concurrency tests
+    // =========================================================================
+
+    @Test
+    public void concurrentAppend_noDataLoss() throws InterruptedException {
+        int threadCount = 10;
+        int changesPerThread = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            final int threadId = t;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < changesPerThread; i++) {
+                        buffer.append(mainUri, makeChange("t" + threadId + "c" + i, ChangeLayer.EDITOR, i));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        Assert.assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "Threads did not finish in time");
+        executor.shutdown();
+
+        List<BufferedChange> all = buffer.drain(mainUri, ChangeLayer.EDITOR);
+        Assert.assertEquals(all.size(), threadCount * changesPerThread,
+                "All " + (threadCount * changesPerThread) + " changes must be present — no data loss");
+    }
+
+    @Test
+    public void concurrentDrainAndAppend_doesNotThrow() throws InterruptedException {
+        int iterations = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(4);
+        List<Throwable> errors = new ArrayList<>();
+
+        // 2 appenders
+        for (int t = 0; t < 2; t++) {
+            final int threadId = t;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterations; i++) {
+                        buffer.append(mainUri, makeChange("c" + i, ChangeLayer.EDITOR, i));
+                    }
+                } catch (Throwable e) {
+                    synchronized (errors) { errors.add(e); }
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // 2 drainers
+        for (int t = 0; t < 2; t++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterations; i++) {
+                        buffer.drain(mainUri, ChangeLayer.EDITOR);
+                    }
+                } catch (Throwable e) {
+                    synchronized (errors) { errors.add(e); }
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        Assert.assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "Threads did not finish in time");
+        executor.shutdown();
+
+        Assert.assertTrue(errors.isEmpty(), "Concurrent drain+append must not throw: " + errors);
+    }
+}


### PR DESCRIPTION
## Purpose

Implement `ChangeBuffer` (T-031) — a thread-safe per-URI, per-layer delta queue that accumulates pending document changes. This replaces the VFS content-authority model with an append-only buffer, enabling the ChangeApplier to pull and apply changes at batch granularity.

## Approach

Created a new `ChangeBuffer` class backed by:
- `ConcurrentHashMap<DocumentUri, Map<ChangeLayer, ConcurrentLinkedQueue<BufferedChange>>>` for per-URI, per-layer change storage
- `ConcurrentHashMap<DocumentUri, FileEvent>` for closed-document and deferred watcher events
- Atomic `drain(uri, layer)` via `ConcurrentHashMap.compute()` — ensures changes are returned and queue cleared atomically
- Open-document detection via EDITOR layer key presence (not queue emptiness)

## What Was Fixed / Changed

**New ChangeBuffer class provides:**
- `append(DocumentUri, BufferedChange)` — thread-safe routing to correct layer queue
- `drain(DocumentUri, ChangeLayer)` — atomic drain with insertion-order preservation
- `drain(DocumentUri)` — drain all layers in EDITOR → AI → EXPR priority order
- `clear(DocumentUri)` — remove all changes for a URI across all layers
- `hasChanges(DocumentUri)` — check for pending changes
- `routeWatcherEvent(DocumentUri, FileEvent)` — routes to `closedDocChanges` (no EDITOR layer) or `deferredWatcherEvents` (EDITOR layer exists)
- `drainClosedDocChanges()` — atomic drain + clear of closed-document watcher events
- `drainDeferredWatcherEvents()` — atomic drain + clear of deferred watcher events

**Concurrency guarantees:**
- No data loss under concurrent append (verified: 1000 changes from 10 threads)
- No exceptions under concurrent drain + append on same URI

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/` — new ChangeBuffer.java
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/` — new ChangeBufferTest.java

## How Has This Been Tested

**29 unit tests covering:**
- Append: URI routing, layer routing, insertion order, URI independence (4 tests)
- Drain by layer: insertion order, queue clearing, empty cases, layer isolation (5 tests)
- Drain all layers: EDITOR→AI→EXPR priority, clears all, per-layer order preservation (4 tests)
- Clear: removes all data, URI isolation, no-op on empty (3 tests)
- HasChanges: false/true after append/drain/clear operations (6 tests)
- Watcher event routing: open→deferred, closed→closed, layer-key persistence (3 tests)
- DrainClosedDocChanges: atomic drain + clear, empty case (2 tests)
- Concurrency: 10 threads × 100 appends (1000 total, no data loss), 2 appenders + 2 drainers (no exceptions)

All tests pass in the test suite.

## Remarks & Notes

- Depends on T-025 (ChangeLayer enum and BufferedChange record) — already completed
- Open-document detection relies on EDITOR layer **key** presence, not queue emptiness — this correctly preserves open state even after the ChangeApplier drains the queue
- Ready for use by T-035 (ChangeApplier), T-044 (DocumentService merge), T-045 (TOML changes), T-053 (ChangeBufferAcceptanceTest)
