### PR TITLE
Update compilation event subscriptions

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
@@ -150,7 +150,8 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
                 this::handleWorkspaceEvent);
 
         eventBus.subscribe("ce-document-events", SubscriberTier.COALESCEABLE,
-                Set.of(EventKind.WM_DOCUMENT_CHANGED,
+                Set.of(EventKind.WM_DOCUMENT_OPENED,
+                       EventKind.WM_DOCUMENT_CHANGED,
                        EventKind.WM_FILE_WATCHED_CHANGED),
                 this::handleDocumentEvent);
     }
@@ -177,12 +178,17 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
 
     private void handleDocumentEvent(DomainEvent event) {
         switch (event.eventKind()) {
+            case WM_DOCUMENT_OPENED -> handleDocumentOpened(event);
             case WM_DOCUMENT_CHANGED -> handleDocumentChanged(event);
-            case WM_FILE_WATCHED_CHANGED -> handleConfigFileChanged(event);
+            case WM_FILE_WATCHED_CHANGED -> handleFileWatchedChanged(event);
             default -> {
                 // No-op for unexpected event kinds
             }
         }
+    }
+
+    private void handleDocumentOpened(DomainEvent event) {
+        handleDocumentChanged(event);
     }
 
     private void handleDocumentChanged(DomainEvent event) {
@@ -194,10 +200,9 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
         }
     }
 
-    private void handleConfigFileChanged(DomainEvent event) {
+    private void handleFileWatchedChanged(DomainEvent event) {
         SourceRoot sourceRoot = reconstructSourceRoot(event);
-        String scope = event.coalesceScope();
-        if ("DEPENDENCY_GRAPH".equals(scope)) {
+        if (isDependencyGraphChange(event.coalesceScope())) {
             CompilationPipeline pipeline = pipelines.get(sourceRoot);
             if (pipeline != null) {
                 ContentVersion nextVersion = new ContentVersion(versionCounter.getAndIncrement());
@@ -243,7 +248,11 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
     }
 
     private SourceRoot reconstructSourceRoot(DomainEvent event) {
-        return new SourceRoot(Path.of(event.coalesceScope()).normalize());
+        return new SourceRoot(Path.of(event.sourceContext()).normalize());
+    }
+
+    private boolean isDependencyGraphChange(String scope) {
+        return "DEPENDENCY_GRAPH".equals(scope) || scope.contains("|DEPENDENCY_GRAPH|");
     }
 
     // ---- Inner Class: CircuitBreakerAction ----

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/observability/WorkspaceTraceLogger.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/observability/WorkspaceTraceLogger.java
@@ -178,15 +178,16 @@ public class WorkspaceTraceLogger implements AutoCloseable {
                  COMPILER_SNAPSHOT_PUBLISHED,
                  COMPILER_COMPILATION_CANCELLED -> "DEBUG";
             case COMPILER_RESOLUTION_COMPLETED,
-                 CE_E5A_RESOLUTION_DIAGNOSTICS_READY,
-                 CE_E5B_COMPILATION_DIAGNOSTICS_READY,
-                 CE_RESOLUTION_RECOVERED,
-                 WORKSPACE_PROJECT_TIER_CHANGED,
-                 WORKSPACE_BATCH_PROJECTS_REGISTERED,
-                 WORKSPACE_LOCKING_MODE_CHANGED,
-                 EXECUTION_PROCESS_OUTPUT,
-                 CACHE_INVALIDATION_REQUESTED,
-                 RM_E1_HEAP_PRESSURE_DETECTED -> "TRACE";
+                  CE_E5A_RESOLUTION_DIAGNOSTICS_READY,
+                  CE_E5B_COMPILATION_DIAGNOSTICS_READY,
+                  CE_RESOLUTION_RECOVERED,
+                  WORKSPACE_PROJECT_TIER_CHANGED,
+                  WORKSPACE_BATCH_PROJECTS_REGISTERED,
+                  WORKSPACE_LOCKING_MODE_CHANGED,
+                  EXECUTION_PROCESS_OUTPUT,
+                  CACHE_INVALIDATION_REQUESTED,
+                  RM_E1_HEAP_PRESSURE_DETECTED -> "TRACE";
+            default -> "TRACE";
         };
     }
 

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
@@ -168,11 +168,10 @@ public class CompilationServiceImplTest {
     // ---- Document Events ----
 
     @Test
-    public void dse2_documentChanged_requestsCompilation() throws InterruptedException {
+    public void wmDocumentOpened_requestsCompilation() throws InterruptedException {
         CountDownLatch firstCompiled = new CountDownLatch(1);
         CountDownLatch secondCompiled = new CountDownLatch(1);
         AtomicInteger compileCount = new AtomicInteger(0);
-        // Use pre-created mockSnapshot
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             int count = compileCount.incrementAndGet();
             if (count == 1) {
@@ -186,17 +185,16 @@ public class CompilationServiceImplTest {
         publishWmE1(TEST_ROOT);
         Assert.assertTrue(firstCompiled.await(3, TimeUnit.SECONDS), "Initial compilation");
 
-        publishDSE2(TEST_ROOT);
+        publishWmDocumentOpened(TEST_ROOT);
         Assert.assertTrue(secondCompiled.await(3, TimeUnit.SECONDS),
-                "DS-E2 should request compilation");
+                "WM_DOCUMENT_OPENED should request compilation");
     }
 
     @Test
-    public void dse4_configFileChanged_dependencyGraph_requestsCompilation() throws InterruptedException {
+    public void wmDocumentChanged_requestsCompilation() throws InterruptedException {
         CountDownLatch firstCompiled = new CountDownLatch(1);
         CountDownLatch secondCompiled = new CountDownLatch(1);
         AtomicInteger compileCount = new AtomicInteger(0);
-        // Use pre-created mockSnapshot
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             int count = compileCount.incrementAndGet();
             if (count == 1) {
@@ -210,15 +208,37 @@ public class CompilationServiceImplTest {
         publishWmE1(TEST_ROOT);
         Assert.assertTrue(firstCompiled.await(3, TimeUnit.SECONDS), "Initial compilation");
 
-        publishDSE4WithScope(TEST_ROOT, "DEPENDENCY_GRAPH");
+        publishWmDocumentChanged(TEST_ROOT);
         Assert.assertTrue(secondCompiled.await(3, TimeUnit.SECONDS),
-                "DS-E4 with DEPENDENCY_GRAPH scope should request compilation");
+                "WM_DOCUMENT_CHANGED should request compilation");
     }
 
     @Test
-    public void dse4_configFileChanged_configuration_doesNotRequest() throws InterruptedException {
+    public void wmFileWatchedChanged_dependencyGraph_requestsCompilation() throws InterruptedException {
         CountDownLatch firstCompiled = new CountDownLatch(1);
-        // Use pre-created mockSnapshot
+        CountDownLatch secondCompiled = new CountDownLatch(1);
+        AtomicInteger compileCount = new AtomicInteger(0);
+        service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
+            int count = compileCount.incrementAndGet();
+            if (count == 1) {
+                firstCompiled.countDown();
+            } else if (count == 2) {
+                secondCompiled.countDown();
+            }
+            return mockSnapshot;
+        }, 50);
+
+        publishWmE1(TEST_ROOT);
+        Assert.assertTrue(firstCompiled.await(3, TimeUnit.SECONDS), "Initial compilation");
+
+        publishWmFileWatchedChanged(TEST_ROOT, "DEPENDENCY_GRAPH");
+        Assert.assertTrue(secondCompiled.await(3, TimeUnit.SECONDS),
+                "WM_FILE_WATCHED_CHANGED with DEPENDENCY_GRAPH scope should request compilation");
+    }
+
+    @Test
+    public void wmFileWatchedChanged_configuration_doesNotRequest() throws InterruptedException {
+        CountDownLatch firstCompiled = new CountDownLatch(1);
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             firstCompiled.countDown();
             return mockSnapshot;
@@ -227,7 +247,7 @@ public class CompilationServiceImplTest {
         publishWmE1(TEST_ROOT);
         Assert.assertTrue(firstCompiled.await(3, TimeUnit.SECONDS), "Initial compilation");
 
-        publishDSE4WithScope(TEST_ROOT, "CONFIGURATION");
+        publishWmFileWatchedChanged(TEST_ROOT, "CONFIGURATION");
         Thread.sleep(300);
 
         // Verify no second compilation triggered
@@ -434,14 +454,20 @@ public class CompilationServiceImplTest {
                 EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED));
     }
 
-    private void publishDSE2(SourceRoot sr) {
+    private void publishWmDocumentOpened(SourceRoot sr) {
         eventBus.publish(new DomainEvent(Instant.now(), sr.path().toString(),
-                EventKind.WM_DOCUMENT_CHANGED));
+                EventKind.WM_DOCUMENT_OPENED, sr.path().resolve("main.bal").toString()));
     }
 
-    private void publishDSE4WithScope(SourceRoot sr, String scope) {
+    private void publishWmDocumentChanged(SourceRoot sr) {
         eventBus.publish(new DomainEvent(Instant.now(), sr.path().toString(),
-                EventKind.WM_FILE_WATCHED_CHANGED, scope));
+                EventKind.WM_DOCUMENT_CHANGED, sr.path().resolve("main.bal").toString()));
+    }
+
+    private void publishWmFileWatchedChanged(SourceRoot sr, String scope) {
+        eventBus.publish(new DomainEvent(Instant.now(), sr.path().toString(),
+                EventKind.WM_FILE_WATCHED_CHANGED,
+                sr.path().resolve("Dependencies.toml") + "|" + scope + "|Changed"));
     }
 
 }


### PR DESCRIPTION
## Purpose

Keep compilation triggers working after the workspace/document event taxonomy migration to WM-scoped events.

## Approach

Updated `CompilationServiceImpl` to subscribe to the new WM document events and route them through the existing compilation trigger paths. The handler now reconstructs the source root from the event source context and preserves dependency-graph config change handling. Also aligned the observability event-kind switch and refreshed the targeted test coverage.

## What Was Fixed / Changed

- `CompilationServiceImpl` now reacts to `WM_DOCUMENT_OPENED`, `WM_DOCUMENT_CHANGED`, and `WM_FILE_WATCHED_CHANGED`.
- Document open and document change events both trigger compilation through the existing pipeline path.
- File-watch events still trigger compilation only for dependency-graph changes.
- Deprecated DS-E* references were removed from the compilation service wiring.
- `WorkspaceTraceLogger` was kept in sync with the updated event kinds so the module compiles cleanly.
- `CompilationServiceImplTest` now covers the WM event payloads and compilation triggers.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine`
- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/observability`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine`

## How Has This Been Tested

- Ran `./gradlew :langserver-core:test --tests org.ballerinalang.langserver.workspace.compilerengine.CompilationServiceImplTest`

## Remarks & Notes

- No TODOs or FIXMEs were introduced.
- File-watch payload handling now expects the encoded scope/change metadata used by the WM event path.
