### PR TITLE
Read locking mode from project options

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectService.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectService.java
@@ -58,19 +58,12 @@ public interface ProjectService {
     Module module(Path path, CancelChecker cancelChecker);
 
     /**
-     * Sets the runtime locking mode.
-     *
-     * @param mode locking mode
-     * @param authority source authority
-     */
-    void setLockingMode(LockingMode mode, LockingModeAuthority authority);
-
-    /**
      * Returns the current locking mode.
      *
+     * @param project project providing compilation options
      * @return current locking mode
      */
-    LockingMode getLockingMode();
+    LockingMode getLockingMode(Project project);
 
     /**
      * Batch-registers all Ballerina projects found under the given workspace folder paths (WM-C2).

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
@@ -61,7 +61,6 @@ import java.util.concurrent.ExecutionException;
  *   <li>Register self as ProjectRegistry listener for eviction/batch events</li>
  *   <li>Subscribe to incoming domain events</li>
  *   <li>Subscribe to RM-E1 heap pressure events</li>
- *   <li>Initialize locking mode to SOFT</li>
  * </ol>
  * </p>
  *
@@ -76,7 +75,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private final EventSyncPubSubHolder eventBus;
     private final ProjectLoader loader;
     private final ConcurrentHashMap<SourceRoot, Project> ballerinaProjects;
-    private final LockingModeController lockingModeController;
+
     /**
      * Constructs a project service with full wiring of dependencies.
      *
@@ -85,7 +84,6 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
      *   <li>Wire self as registry listener</li>
      *   <li>Subscribe to domain events</li>
      *   <li>Subscribe to RM-E1 heap pressure events</li>
-     *   <li>Initialize locking mode</li>
      * </ol>
      * </p>
      *
@@ -107,7 +105,6 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         this.eventBus = eventBus;
         this.loader = loader;
         this.ballerinaProjects = new ConcurrentHashMap<>();
-        this.lockingModeController = new LockingModeController(eventBus);
 
         // 1. Wire self as registry listener for eviction and batch events
         registry.addListener(this);
@@ -124,7 +121,6 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         eventBus.subscribe("rm-heap-pressure", SubscriberTier.CRITICAL,
                 Set.of(EventKind.RM_E1_HEAP_PRESSURE_DETECTED), this::onHeapPressureDetected);
 
-        // 4. Default locking mode is already initialized above
     }
 
     // =========================================================================
@@ -188,16 +184,9 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     }
 
     @Override
-    public void setLockingMode(LockingMode mode, LockingModeAuthority authority) {
-        Objects.requireNonNull(mode, "mode must not be null");
-        Objects.requireNonNull(authority, "authority must not be null");
-
-        lockingModeController.setMode(mode, authority, "external-set");
-    }
-
-    @Override
-    public LockingMode getLockingMode() {
-        return lockingModeController.getMode();
+    public LockingMode getLockingMode(Project project) {
+        Objects.requireNonNull(project, "project must not be null");
+        return LockingMode.valueOf(project.buildOptions().lockingMode().name());
     }
 
     @Override
@@ -371,15 +360,6 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
             project.transitionKind(target);
             publishWm(EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED, root);
         });
-    }
-
-    /**
-     * Returns the locking mode controller for package-internal access.
-     *
-     * @return the locking mode controller
-     */
-    LockingModeController lockingModeController() {
-        return lockingModeController;
     }
 
     /**

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WorkspaceContextContractsTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WorkspaceContextContractsTest.java
@@ -101,7 +101,7 @@ public class WorkspaceContextContractsTest {
     @Test
     public void projectService_matchesContractSignatures() throws ReflectiveOperationException {
         Assert.assertTrue(ProjectService.class.isInterface());
-        Assert.assertEquals(ProjectService.class.getMethods().length, 9);
+        Assert.assertEquals(ProjectService.class.getMethods().length, 8);
 
         Method loadOrCreate = ProjectService.class.getMethod("loadOrCreate", Path.class, CancelChecker.class);
         Assert.assertEquals(loadOrCreate.getReturnType(), Project.class);
@@ -112,11 +112,7 @@ public class WorkspaceContextContractsTest {
         Method module = ProjectService.class.getMethod("module", Path.class, CancelChecker.class);
         Assert.assertEquals(module.getReturnType(), Module.class);
 
-        Method setLockingMode = ProjectService.class.getMethod("setLockingMode", LockingMode.class,
-                LockingModeAuthority.class);
-        Assert.assertEquals(setLockingMode.getReturnType(), Void.TYPE);
-
-        Method getLockingMode = ProjectService.class.getMethod("getLockingMode");
+        Method getLockingMode = ProjectService.class.getMethod("getLockingMode", Project.class);
         Assert.assertEquals(getLockingMode.getReturnType(), LockingMode.class);
 
         Method registerWorkspace = ProjectService.class.getMethod("registerWorkspace", java.util.List.class);

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
@@ -19,6 +19,8 @@
 package org.ballerinalang.langserver.workspace.workspacemanager;
 
 import io.ballerina.projects.Project;
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.environment.PackageLockingMode;
 import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
@@ -185,27 +187,36 @@ public class ProjectServiceTest {
 
     @Test(groups = "locking-mode")
     public void lockingMode_defaultIsSOFT() {
-        Assert.assertEquals(service.getLockingMode(), LockingMode.SOFT,
-                "Default locking mode should be SOFT");
+        Project project = Mockito.mock(Project.class);
+        BuildOptions buildOptions = Mockito.mock(BuildOptions.class);
+        Mockito.when(project.buildOptions()).thenReturn(buildOptions);
+        Mockito.when(buildOptions.lockingMode()).thenReturn(PackageLockingMode.SOFT);
+
+        Assert.assertEquals(service.getLockingMode(project), LockingMode.SOFT,
+                "Default locking mode should be read from project options");
     }
 
     @Test(groups = "locking-mode")
-    public void lockingMode_setAndGet() {
-        service.setLockingMode(LockingMode.HARD, LockingModeAuthority.EXTERNAL_ENTITY);
-        Assert.assertEquals(service.getLockingMode(), LockingMode.HARD,
-                "Locking mode should be HARD after setting");
+    public void lockingMode_readsFromProjectCompilationOptions() {
+        Project project = Mockito.mock(Project.class);
+        BuildOptions buildOptions = Mockito.mock(BuildOptions.class);
+        Mockito.when(project.buildOptions()).thenReturn(buildOptions);
+        Mockito.when(buildOptions.lockingMode()).thenReturn(PackageLockingMode.HARD);
+
+        Assert.assertEquals(service.getLockingMode(project), LockingMode.HARD,
+                "Locking mode should come from project build options");
     }
 
     @Test(groups = "locking-mode")
-    public void lockingMode_setNullModeThrowsNPE() {
+    public void lockingMode_nullProjectThrowsNPE() {
         Assert.assertThrows(NullPointerException.class,
-                () -> service.setLockingMode(null, LockingModeAuthority.EXTERNAL_ENTITY));
+                () -> service.getLockingMode(null));
     }
 
     @Test(groups = "locking-mode")
-    public void lockingMode_setNullAuthorityThrowsNPE() {
-        Assert.assertThrows(NullPointerException.class,
-                () -> service.setLockingMode(LockingMode.HARD, null));
+    public void lockingMode_projectServiceImplDoesNotDeclareControllerField() {
+        Assert.assertThrows(NoSuchFieldException.class,
+                () -> ProjectServiceImpl.class.getDeclaredField("lockingModeController"));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Purpose

Remove mutable locking-mode state from `ProjectServiceImpl` and make the
service read locking mode from each project's compilation options, aligning
the workspace manager with the recovery-ladder design.

## Approach

Deleted the `LockingModeController` dependency from `ProjectServiceImpl`,
changed the service contract to accept a `Project` when resolving the current
locking mode, and mapped the Ballerina `BuildOptions` value into the local
`LockingMode` enum.

## What Was Fixed / Changed

- Removed runtime locking-mode setters from `ProjectService`.
- Replaced global locking-mode reads with per-project reads.
- Updated contract tests and service tests to verify the new API.
- Kept `LockingModeController` in the codebase for the later cleanup task.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace`

## How Has This Been Tested

- Ran `./gradlew :langserver-core:test --tests org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceTest --tests org.ballerinalang.langserver.workspace.WorkspaceContextContractsTest`
- Verified the worktree is clean after commit.

## Remarks & Notes

- `LockingModeController` remains intentionally undeleted; that cleanup is
  reserved for T-050.
- The task file still tracks this as TODO, so the ledger/task metadata may
  need a separate update.
