### PR TITLE
Move document classes into workspacemanager

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/documentstore/DocumentServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/documentstore/DocumentServiceImpl.java
@@ -23,6 +23,7 @@ import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
+import org.ballerinalang.langserver.workspace.workspacemanager.FileWatcherProcessor;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/documentstore/VirtualFileSystem.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/documentstore/VirtualFileSystem.java
@@ -18,6 +18,8 @@
 
 package org.ballerinalang.langserver.workspace.documentstore;
 
+import org.ballerinalang.langserver.workspace.workspacemanager.Document;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/Document.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/Document.java
@@ -16,7 +16,13 @@
  *  under the License.
  */
 
-package org.ballerinalang.langserver.workspace.documentstore;
+package org.ballerinalang.langserver.workspace.workspacemanager;
+
+import org.ballerinalang.langserver.workspace.documentstore.DocumentState;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.ballerinalang.langserver.workspace.documentstore.FileId;
+import org.ballerinalang.langserver.workspace.documentstore.TextRange;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/FileWatcherProcessor.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/FileWatcherProcessor.java
@@ -16,8 +16,10 @@
  *  under the License.
  */
 
-package org.ballerinalang.langserver.workspace.documentstore;
+package org.ballerinalang.langserver.workspace.workspacemanager;
 
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.ballerinalang.langserver.workspace.documentstore.VirtualFileSystem;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/documentstore/DocumentTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/documentstore/DocumentTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.langserver.workspace.documentstore;
 
+import org.ballerinalang.langserver.workspace.workspacemanager.Document;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/documentstore/FileWatcherProcessorTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/documentstore/FileWatcherProcessorTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.langserver.workspace.documentstore;
 
+import org.ballerinalang.langserver.workspace.workspacemanager.FileWatcherProcessor;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 import org.testng.Assert;


### PR DESCRIPTION
## Purpose

Align the document-store merge work with ADR-046 by moving the core
document model into the workspace manager bounded context.

## Approach

Relocate `Document` and `FileWatcherProcessor` into
`workspace/workspacemanager`, then update the remaining document-store
code and tests to reference the new package location.

## What Was Fixed / Changed

- `Document` now lives under the workspace manager package.
- `FileWatcherProcessor` now lives under the workspace manager package.
- `VirtualFileSystem`, `DocumentServiceImpl`, and tests import the moved
  classes from their new location.
- No runtime behavior changed; this is a package migration only.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/documentstore`
- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/documentstore`

## How Has This Been Tested

- `./gradlew :langserver-core:compileJava :langserver-core:compileTestJava`
- `./gradlew :langserver-core:test --tests "org.ballerinalang.langserver.workspace.documentstore.DocumentTest" --tests "org.ballerinalang.langserver.workspace.documentstore.FileWatcherProcessorTest"`

## Remarks & Notes

- `SandboxModule.java` was intentionally left in place; T-049 removes it.
- `branch-diff` could not resolve `replace-wm` in this worktree, so the
  description was derived from the committed changes and recent history.
