### PR TITLE
Implement resolution-first recovery

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.workspace;
 
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationServiceImpl;
-import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
 import org.ballerinalang.langserver.workspace.documentstore.DocumentServiceImpl;
 import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
 import org.ballerinalang.langserver.workspace.documentstore.VirtualFileSystem;
@@ -65,7 +65,7 @@ public final class WiringConfiguration implements AutoCloseable {
     private final CompilationServiceImpl compilationService;
     private final ExecutionServiceImpl executionService;
     private final WorkspaceTraceLogger traceLogger;
-    private final SnapshotStore snapshotStore;
+    private final DualSnapshotStore snapshotStore;
     private final ProjectRegistry projectRegistry;
 
     private WiringConfiguration(Builder builder) {
@@ -250,7 +250,7 @@ public final class WiringConfiguration implements AutoCloseable {
         return traceLogger;
     }
 
-    public SnapshotStore snapshotStore() {
+    public DualSnapshotStore snapshotStore() {
         return snapshotStore;
     }
 
@@ -274,7 +274,7 @@ public final class WiringConfiguration implements AutoCloseable {
         private EventSyncPubSubHolder eventBus;
         private VirtualFileSystem virtualFileSystem;
         private Function<Path, Path> projectRootResolver;
-        private SnapshotStore snapshotStore;
+        private DualSnapshotStore snapshotStore;
         private CompilationPipeline.CompilationAction compilationAction;
         private ProjectRegistry projectRegistry;
         private UriResolver uriResolver;
@@ -297,7 +297,7 @@ public final class WiringConfiguration implements AutoCloseable {
             return this;
         }
 
-        public Builder snapshotStore(SnapshotStore snapshotStore) {
+        public Builder snapshotStore(DualSnapshotStore snapshotStore) {
             this.snapshotStore = snapshotStore;
             return this;
         }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
@@ -24,6 +24,7 @@ import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.environment.PackageLockingMode;
@@ -34,10 +35,11 @@ import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
 import org.ballerinalang.langserver.workspace.compilerengine.CompileTask;
 import org.ballerinalang.langserver.workspace.compilerengine.FailureType;
-import org.ballerinalang.langserver.workspace.compilerengine.ProjectSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
 import org.ballerinalang.langserver.workspace.compilerengine.RecoveryLadder;
 import org.ballerinalang.langserver.workspace.compilerengine.ResolutionResult;
-import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
 import org.ballerinalang.langserver.workspace.documentstore.VirtualFileSystem;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.execution.GracePeriod;
@@ -81,7 +83,7 @@ public final class WorkspaceManagerFacadeFactory {
 
         EventSyncPubSubHolder eventBus = new EventSyncPubSubHolder();
         VirtualFileSystem vfs = new VirtualFileSystem();
-        SnapshotStore snapshotStore = new SnapshotStore(100);
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
         ProjectRegistry projectRegistry = new ProjectRegistry(MemoryBudget.ofMb(512));
         UriResolver uriResolver = new UriResolver();
         GracePeriod gracePeriod = GracePeriod.ofMillis(2000);
@@ -107,7 +109,7 @@ public final class WorkspaceManagerFacadeFactory {
             }
 
             @Override
-            public ProjectSnapshot compile(CompileTask task) {
+            public StableSnapshot compile(CompileTask task) {
                 return snapshot(projectService().loadOrCreate(task.sourceRoot().path(), null), task.contentVersion());
             }
 
@@ -144,27 +146,31 @@ public final class WorkspaceManagerFacadeFactory {
                 return ps;
             }
 
-            private ProjectSnapshot snapshot(Project project, org.ballerinalang.langserver.workspace.documentstore.ContentVersion version) {
+            private StableSnapshot snapshot(Project project,
+                                            org.ballerinalang.langserver.workspace.documentstore.ContentVersion version) {
                 PackageCompilation compilation = project.currentPackage().getCompilation();
-                Module module = project.currentPackage().getDefaultModule();
-                SemanticModel semanticModel = compilation.getSemanticModel(module.moduleId());
-                SyntaxTree syntaxTree = null;
-                for (DocumentId docId : module.documentIds()) {
-                    syntaxTree = module.document(docId).syntaxTree();
-                    break;
-                }
-                Map<Path, SyntaxTree> syntaxTrees = new HashMap<>();
+                Map<DocumentId, SyntaxTree> syntaxTrees = new HashMap<>();
+                Map<Path, DocumentId> pathToDocumentIds = new HashMap<>();
+                Map<ModuleId, SemanticModel> semanticModels = new HashMap<>();
                 project.currentPackage().moduleIds().forEach(moduleId -> {
                     Module packageModule = project.currentPackage().module(moduleId);
+                    semanticModels.put(moduleId, compilation.getSemanticModel(moduleId));
                     packageModule.documentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
-                            syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
+                            {
+                                syntaxTrees.put(docId, packageModule.document(docId).syntaxTree());
+                                pathToDocumentIds.put(path.normalize(), docId);
+                            }));
                     packageModule.testDocumentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
-                            syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
+                            {
+                                syntaxTrees.put(docId, packageModule.document(docId).syntaxTree());
+                                pathToDocumentIds.put(path.normalize(), docId);
+                            }));
                 });
-                if (syntaxTree == null || syntaxTrees.isEmpty()) {
+                if (syntaxTrees.isEmpty() || semanticModels.isEmpty()) {
                     throw new RuntimeException("No source documents in project: " + project.sourceRoot());
                 }
-                return new ProjectSnapshot(compilation, semanticModel, syntaxTree, syntaxTrees, version);
+                return new MaterializedStableSnapshot(syntaxTrees, pathToDocumentIds, semanticModels,
+                        compilation, version);
             }
 
             private CompilationOptions compilationOptions(LockingMode lockingMode) {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
@@ -78,7 +78,6 @@ public final class WorkspaceManagerFacadeFactory {
     public static WorkspaceManager create(LanguageServerContext serverContext) {
         BuildOptions buildOptions = BuildOptions.builder()
                 .setOffline(CommonUtil.COMPILE_OFFLINE)
-                .setSticky(false)
                 .build();
 
         EventSyncPubSubHolder eventBus = new EventSyncPubSubHolder();
@@ -176,7 +175,6 @@ public final class WorkspaceManagerFacadeFactory {
             private CompilationOptions compilationOptions(LockingMode lockingMode) {
                 return CompilationOptions.builder()
                         .setOffline(CommonUtil.COMPILE_OFFLINE)
-                        .setSticky(false)
                         .setLockingMode(PackageLockingMode.valueOf(lockingMode.name()))
                         .build();
             }
@@ -184,7 +182,6 @@ public final class WorkspaceManagerFacadeFactory {
             private BuildOptions buildOptions(LockingMode lockingMode) {
                 return BuildOptions.builder()
                         .setOffline(CommonUtil.COMPILE_OFFLINE)
-                        .setSticky(false)
                         .setLockingMode(PackageLockingMode.valueOf(lockingMode.name()))
                         .build();
             }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WorkspaceManagerFacadeFactory.java
@@ -21,21 +21,29 @@ package org.ballerinalang.langserver.workspace;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.environment.PackageLockingMode;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompilerApi;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
+import org.ballerinalang.langserver.workspace.compilerengine.CompileTask;
+import org.ballerinalang.langserver.workspace.compilerengine.FailureType;
 import org.ballerinalang.langserver.workspace.compilerengine.ProjectSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.RecoveryLadder;
+import org.ballerinalang.langserver.workspace.compilerengine.ResolutionResult;
 import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
 import org.ballerinalang.langserver.workspace.documentstore.VirtualFileSystem;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.execution.GracePeriod;
 import org.ballerinalang.langserver.workspace.lspgateway.ClientSession;
 import org.ballerinalang.langserver.workspace.lspgateway.WorkspaceManagerFacadeImpl;
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
 import org.ballerinalang.langserver.workspace.workspacemanager.MemoryBudget;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceImpl;
@@ -45,6 +53,7 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -80,33 +89,103 @@ public final class WorkspaceManagerFacadeFactory {
         // Holder to break the circular reference: compilationAction -> projectService
         ProjectServiceImpl[] projectServiceHolder = {null};
 
-        CompilationPipeline.CompilationAction compilationAction = task -> {
-            ProjectServiceImpl ps = projectServiceHolder[0];
-            if (ps == null) {
-                throw new IllegalStateException("ProjectService not yet initialized");
+        CompilationPipeline.CompilationAction compilationAction = new CompilationPipeline.CompilationAction() {
+            @Override
+            public ResolutionResult resolve(CompileTask task) {
+                ProjectServiceImpl ps = projectService();
+                LockingMode lockingMode = currentLockingMode(task);
+                try {
+                    Project project = ps.loadOrCreate(task.sourceRoot().path(), null);
+                    project.currentPackage().getResolution(compilationOptions(lockingMode));
+                    return new ResolutionResult(task.sourceRoot(), List.of(), true);
+                } catch (RuntimeException e) {
+                    String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+                    return new ResolutionResult(task.sourceRoot(), List.of(
+                            new ResolutionResult.ResolutionDiagnostic(ResolutionResult.Severity.ERROR,
+                                    message, task.sourceRoot().path().toString())), false);
+                }
             }
-            io.ballerina.projects.Project project =
-                    ps.loadOrCreate(task.sourceRoot().path(), null);
-            PackageCompilation compilation = project.currentPackage().getCompilation();
-            Module module = project.currentPackage().getDefaultModule();
-            SemanticModel semanticModel = compilation.getSemanticModel(module.moduleId());
-            SyntaxTree syntaxTree = null;
-            for (DocumentId docId : module.documentIds()) {
-                syntaxTree = module.document(docId).syntaxTree();
-                break;
+
+            @Override
+            public ProjectSnapshot compile(CompileTask task) {
+                return snapshot(projectService().loadOrCreate(task.sourceRoot().path(), null), task.contentVersion());
             }
-            Map<Path, SyntaxTree> syntaxTrees = new HashMap<>();
-            project.currentPackage().moduleIds().forEach(moduleId -> {
-                Module packageModule = project.currentPackage().module(moduleId);
-                packageModule.documentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
-                        syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
-                packageModule.testDocumentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
-                        syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
-            });
-            if (syntaxTree == null || syntaxTrees.isEmpty()) {
-                throw new RuntimeException("No source documents in project: " + task.sourceRoot());
+
+            @Override
+            public LockingMode currentLockingMode(CompileTask task) {
+                ProjectServiceImpl ps = projectService();
+                Project project = ps.loadOrCreate(task.sourceRoot().path(), null);
+                return ps.getLockingMode(project);
             }
-            return new ProjectSnapshot(compilation, semanticModel, syntaxTree, syntaxTrees, task.contentVersion());
+
+            @Override
+            public CompilationPipeline.RecoveryResult recover(CompileTask task, LockingMode initialMode, Throwable cause) {
+                LockingMode recoveryMode = nextMorePermissiveMode(initialMode);
+                while (recoveryMode != initialMode) {
+                    try {
+                        Project transientProject = BallerinaCompilerApi.getInstance()
+                                .loadProject(task.sourceRoot().path(), buildOptions(recoveryMode));
+                        transientProject.currentPackage().getResolution(compilationOptions(recoveryMode));
+                        transientProject.currentPackage().getCompilation();
+                        return CompilationPipeline.RecoveryResult.success();
+                    } catch (RuntimeException ignored) {
+                        initialMode = recoveryMode;
+                        recoveryMode = nextMorePermissiveMode(recoveryMode);
+                    }
+                }
+                return CompilationPipeline.RecoveryResult.exhausted();
+            }
+
+            private ProjectServiceImpl projectService() {
+                ProjectServiceImpl ps = projectServiceHolder[0];
+                if (ps == null) {
+                    throw new IllegalStateException("ProjectService not yet initialized");
+                }
+                return ps;
+            }
+
+            private ProjectSnapshot snapshot(Project project, org.ballerinalang.langserver.workspace.documentstore.ContentVersion version) {
+                PackageCompilation compilation = project.currentPackage().getCompilation();
+                Module module = project.currentPackage().getDefaultModule();
+                SemanticModel semanticModel = compilation.getSemanticModel(module.moduleId());
+                SyntaxTree syntaxTree = null;
+                for (DocumentId docId : module.documentIds()) {
+                    syntaxTree = module.document(docId).syntaxTree();
+                    break;
+                }
+                Map<Path, SyntaxTree> syntaxTrees = new HashMap<>();
+                project.currentPackage().moduleIds().forEach(moduleId -> {
+                    Module packageModule = project.currentPackage().module(moduleId);
+                    packageModule.documentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
+                            syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
+                    packageModule.testDocumentIds().forEach(docId -> project.documentPath(docId).ifPresent(path ->
+                            syntaxTrees.put(path.normalize(), packageModule.document(docId).syntaxTree())));
+                });
+                if (syntaxTree == null || syntaxTrees.isEmpty()) {
+                    throw new RuntimeException("No source documents in project: " + project.sourceRoot());
+                }
+                return new ProjectSnapshot(compilation, semanticModel, syntaxTree, syntaxTrees, version);
+            }
+
+            private CompilationOptions compilationOptions(LockingMode lockingMode) {
+                return CompilationOptions.builder()
+                        .setOffline(CommonUtil.COMPILE_OFFLINE)
+                        .setSticky(false)
+                        .setLockingMode(PackageLockingMode.valueOf(lockingMode.name()))
+                        .build();
+            }
+
+            private BuildOptions buildOptions(LockingMode lockingMode) {
+                return BuildOptions.builder()
+                        .setOffline(CommonUtil.COMPILE_OFFLINE)
+                        .setSticky(false)
+                        .setLockingMode(PackageLockingMode.valueOf(lockingMode.name()))
+                        .build();
+            }
+
+            private LockingMode nextMorePermissiveMode(LockingMode mode) {
+                return RecoveryLadder.nextMode(mode, FailureType.RESOLUTION_SUCCEEDED);
+            }
         };
 
         WiringConfiguration config = WiringConfiguration.builder()

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
 
 import java.time.Instant;
@@ -50,9 +51,37 @@ public class CompilationPipeline implements AutoCloseable {
     /**
      * Strategy for performing the actual compilation work.
      */
-    @FunctionalInterface
     public interface CompilationAction {
+        default ResolutionResult resolve(CompileTask task) throws Exception {
+            return new ResolutionResult(task.sourceRoot(), java.util.List.of(), true);
+        }
+
         ProjectSnapshot compile(CompileTask task) throws Exception;
+
+        default LockingMode currentLockingMode(CompileTask task) {
+            return LockingMode.LOCKED;
+        }
+
+        default RecoveryResult recover(CompileTask task, LockingMode initialMode, Throwable cause) throws Exception {
+            return RecoveryResult.exhausted();
+        }
+    }
+
+    /**
+     * Recovery outcome for a qualifying compilation failure.
+     *
+     * @param recovered whether transient recovery succeeded
+     * @since 1.7.0
+     */
+    public record RecoveryResult(boolean recovered) {
+
+        public static RecoveryResult success() {
+            return new RecoveryResult(true);
+        }
+
+        public static RecoveryResult exhausted() {
+            return new RecoveryResult(false);
+        }
     }
 
     private final SourceRoot sourceRoot;
@@ -185,6 +214,12 @@ public class CompilationPipeline implements AutoCloseable {
     private void executeCompilation(CompileTask task) {
         activeWorkerThread.set(Thread.currentThread());
         try {
+            ResolutionResult resolutionResult = compilationAction.resolve(task);
+            if (!resolutionResult.success()) {
+                emitEvent(EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY);
+                return;
+            }
+
             ProjectSnapshot snapshot = compilationAction.compile(task);
 
             // Publication guard: discard result if cancelled (ADR-018 Mandate 8)
@@ -203,6 +238,7 @@ public class CompilationPipeline implements AutoCloseable {
                 return;
             }
 
+            emitEvent(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY);
             snapshotStore.publish(sourceRoot, snapshot);
             emitEvent(EventKind.COMPILER_SNAPSHOT_PUBLISHED);
         } catch (CancellationException e) {
@@ -212,6 +248,10 @@ public class CompilationPipeline implements AutoCloseable {
             LOG.fine(() -> "Compilation interrupted for " + sourceRoot);
             emitEvent(EventKind.COMPILER_COMPILATION_CANCELLED);
         } catch (Exception e) {
+            if (isBirCompilationFailure(e)) {
+                scheduleRecovery(task, e);
+                return;
+            }
             LOG.log(Level.WARNING, "Compilation failed for " + sourceRoot, e);
             emitEvent(EventKind.COMPILER_COMPILATION_FAILED);
         } finally {
@@ -221,6 +261,26 @@ public class CompilationPipeline implements AutoCloseable {
             Thread.interrupted();
             // If a newer version is pending, submit it immediately (skip debounce)
             scheduleLatestIfPending(task.contentVersion());
+        }
+    }
+
+    private void scheduleRecovery(CompileTask task, Throwable cause) {
+        compilationWorker.submit(() -> executeRecovery(task, cause));
+    }
+
+    private void executeRecovery(CompileTask task, Throwable cause) {
+        try {
+            RecoveryResult recoveryResult = compilationAction.recover(task, compilationAction.currentLockingMode(task), cause);
+            if (recoveryResult.recovered()) {
+                emitEvent(EventKind.CE_RESOLUTION_RECOVERED);
+                requestCompilation(latestRequestedVersion.updateAndGet(version ->
+                        version != null ? version : task.contentVersion()));
+            } else {
+                emitEvent(EventKind.CE_RESOLUTION_EXHAUSTED);
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Recovery failed for " + sourceRoot, e);
+            emitEvent(EventKind.CE_RESOLUTION_EXHAUSTED);
         }
     }
 
@@ -240,7 +300,6 @@ public class CompilationPipeline implements AutoCloseable {
     }
 
     private void emitEvent(EventKind kind) {
-        System.err.println("[CP] Emitting event: " + kind + " for " + sourceRoot.path());
         try {
             DomainEvent event = new DomainEvent(Instant.now(), "compilation-pipeline", kind,
                     sourceRoot.path().toString());
@@ -248,5 +307,16 @@ public class CompilationPipeline implements AutoCloseable {
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Failed to emit event " + kind + " for " + sourceRoot, e);
         }
+    }
+
+    private boolean isBirCompilationFailure(Throwable error) {
+        String message = error.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase();
+        return normalized.startsWith("failed to load the module")
+                || normalized.contains(".bir")
+                || normalized.contains(" bir ");
     }
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
@@ -56,7 +56,7 @@ public class CompilationPipeline implements AutoCloseable {
             return new ResolutionResult(task.sourceRoot(), java.util.List.of(), true);
         }
 
-        ProjectSnapshot compile(CompileTask task) throws Exception;
+        StableSnapshot compile(CompileTask task) throws Exception;
 
         default LockingMode currentLockingMode(CompileTask task) {
             return LockingMode.LOCKED;
@@ -85,7 +85,7 @@ public class CompilationPipeline implements AutoCloseable {
     }
 
     private final SourceRoot sourceRoot;
-    private final SnapshotStore snapshotStore;
+    private final DualSnapshotStore snapshotStore;
     private final EventSyncPubSubHolder eventBus;
     private final CompilationAction compilationAction;
     private final ScheduledExecutorService debounceScheduler;
@@ -104,8 +104,8 @@ public class CompilationPipeline implements AutoCloseable {
      * @param eventBus          event bus for domain event emission
      * @param compilationAction the actual compilation strategy
      */
-    public CompilationPipeline(SourceRoot sourceRoot, SnapshotStore snapshotStore,
-                               EventSyncPubSubHolder eventBus, CompilationAction compilationAction) {
+    public CompilationPipeline(SourceRoot sourceRoot, DualSnapshotStore snapshotStore,
+                                EventSyncPubSubHolder eventBus, CompilationAction compilationAction) {
         this.sourceRoot = Objects.requireNonNull(sourceRoot, "sourceRoot must not be null");
         this.snapshotStore = Objects.requireNonNull(snapshotStore, "snapshotStore must not be null");
         this.eventBus = Objects.requireNonNull(eventBus, "eventBus must not be null");
@@ -206,6 +206,7 @@ public class CompilationPipeline implements AutoCloseable {
 
         CancellationToken token = new CancellationToken();
         CompileTask task = new CompileTask(sourceRoot, contentVersion, token);
+        snapshotStore.startCompilation(sourceRoot);
         inflightTask.set(task);
 
         compilationWorker.submit(() -> executeCompilation(task));
@@ -213,6 +214,7 @@ public class CompilationPipeline implements AutoCloseable {
 
     private void executeCompilation(CompileTask task) {
         activeWorkerThread.set(Thread.currentThread());
+        boolean published = false;
         try {
             ResolutionResult resolutionResult = compilationAction.resolve(task);
             if (!resolutionResult.success()) {
@@ -220,7 +222,7 @@ public class CompilationPipeline implements AutoCloseable {
                 return;
             }
 
-            ProjectSnapshot snapshot = compilationAction.compile(task);
+            StableSnapshot snapshot = compilationAction.compile(task);
 
             // Publication guard: discard result if cancelled (ADR-018 Mandate 8)
             if (task.isCancelled()) {
@@ -239,7 +241,8 @@ public class CompilationPipeline implements AutoCloseable {
             }
 
             emitEvent(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY);
-            snapshotStore.publish(sourceRoot, snapshot);
+            snapshotStore.publishStable(sourceRoot, snapshot);
+            published = true;
             emitEvent(EventKind.COMPILER_SNAPSHOT_PUBLISHED);
         } catch (CancellationException e) {
             LOG.fine(() -> "Compilation cancelled for " + sourceRoot);
@@ -255,6 +258,9 @@ public class CompilationPipeline implements AutoCloseable {
             LOG.log(Level.WARNING, "Compilation failed for " + sourceRoot, e);
             emitEvent(EventKind.COMPILER_COMPILATION_FAILED);
         } finally {
+            if (!published) {
+                snapshotStore.cancelInProgress(sourceRoot);
+            }
             activeWorkerThread.compareAndSet(Thread.currentThread(), null);
             inflightTask.compareAndSet(task, null);
             // Clear interrupt flag so the worker thread can pick up the next task

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
@@ -59,6 +59,7 @@ public class CompilationPipeline implements AutoCloseable {
         StableSnapshot compile(CompileTask task) throws Exception;
 
         default LockingMode currentLockingMode(CompileTask task) {
+            // Tests and lightweight callers can omit locking-mode wiring; production overrides this.
             return LockingMode.LOCKED;
         }
 

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
@@ -37,10 +37,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -59,7 +61,7 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
 
     private static final Logger LOG = Logger.getLogger(CompilationServiceImpl.class.getName());
 
-    private final SnapshotStore snapshotStore;
+    private final DualSnapshotStore snapshotStore;
     private final EventSyncPubSubHolder eventBus;
     private final CompilationPipeline.CompilationAction baseAction;
     private final long retryDelayMs;
@@ -76,8 +78,8 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
      * @param eventBus event bus for publishing/subscribing to domain events
      * @param baseAction the underlying compilation action to wrap with circuit breaker
      */
-    public CompilationServiceImpl(SnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
-                                 CompilationPipeline.CompilationAction baseAction) {
+    public CompilationServiceImpl(DualSnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
+                                  CompilationPipeline.CompilationAction baseAction) {
         this(snapshotStore, eventBus, baseAction, 500L);
     }
 
@@ -89,8 +91,8 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
      * @param baseAction the underlying compilation action to wrap with circuit breaker
      * @param retryDelayMs delay in milliseconds before retrying a transient failure
      */
-    public CompilationServiceImpl(SnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
-                                 CompilationPipeline.CompilationAction baseAction, long retryDelayMs) {
+    public CompilationServiceImpl(DualSnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
+                                  CompilationPipeline.CompilationAction baseAction, long retryDelayMs) {
         this.snapshotStore = Objects.requireNonNull(snapshotStore, "snapshotStore must not be null");
         this.eventBus = Objects.requireNonNull(eventBus, "eventBus must not be null");
         this.baseAction = Objects.requireNonNull(baseAction, "baseAction must not be null");
@@ -110,23 +112,49 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
 
     @Override
     public SyntaxTree syntaxTree(Path path, CancelChecker cancelChecker) {
-        return findSnapshot(path)
-                .map(snapshot -> snapshot.syntaxTree(path.normalize()))
-                .orElse(null);
+        Optional<SourceRoot> sourceRoot = findSourceRoot(path);
+        if (sourceRoot.isEmpty()) {
+            return null;
+        }
+        MaterializedStableSnapshot stableSnapshot = materialized(snapshotStore.getStable(sourceRoot.get()));
+        if (stableSnapshot != null) {
+            return stableSnapshot.syntaxTree(path);
+        }
+        InProgressSnapshot inProgressSnapshot = snapshotStore.getInProgress(sourceRoot.get());
+        if (inProgressSnapshot instanceof DualSnapshotStore.StoreInProgressSnapshot storeInProgress) {
+            return materialized(storeInProgress.fallbackStableSnapshot()) == null ? null
+                    : materialized(storeInProgress.fallbackStableSnapshot()).syntaxTree(path);
+        }
+        return null;
     }
 
     @Override
     public SemanticModel semanticModel(Path path, CancelChecker cancelChecker) {
-        return findSnapshot(path)
-                .map(ProjectSnapshot::semanticModel)
-                .orElse(null);
+        Optional<SourceRoot> sourceRoot = findSourceRoot(path);
+        if (sourceRoot.isEmpty()) {
+            return null;
+        }
+        MaterializedStableSnapshot stableSnapshot = materialized(snapshotStore.getStable(sourceRoot.get()));
+        if (stableSnapshot != null) {
+            return stableSnapshot.semanticModel(path);
+        }
+        StableSnapshot awaited = awaitInProgress(sourceRoot.get(), cancelChecker);
+        MaterializedStableSnapshot materializedSnapshot = materialized(awaited);
+        return materializedSnapshot == null ? null : materializedSnapshot.semanticModel(path);
     }
 
     @Override
     public PackageCompilation compilation(Path path, CancelChecker cancelChecker) {
-        return findSnapshot(path)
-                .map(ProjectSnapshot::compilation)
-                .orElse(null);
+        Optional<SourceRoot> sourceRoot = findSourceRoot(path);
+        if (sourceRoot.isEmpty()) {
+            return null;
+        }
+        StableSnapshot stableSnapshot = snapshotStore.getStable(sourceRoot.get());
+        if (stableSnapshot != null) {
+            return stableSnapshot.compilation();
+        }
+        StableSnapshot awaited = awaitInProgress(sourceRoot.get(), cancelChecker);
+        return awaited == null ? null : awaited.compilation();
     }
 
     @Override
@@ -241,11 +269,39 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
         }
     }
 
-    private Optional<ProjectSnapshot> findSnapshot(Path path) {
+    private Optional<SourceRoot> findSourceRoot(Path path) {
         return pipelines.keySet().stream()
                 .filter(sr -> path.startsWith(sr.path()))
-                .findFirst()
-                .flatMap(snapshotStore::get);
+                .findFirst();
+    }
+
+    private StableSnapshot awaitInProgress(SourceRoot sourceRoot, CancelChecker cancelChecker) {
+        InProgressSnapshot inProgressSnapshot = snapshotStore.getInProgress(sourceRoot);
+        if (!(inProgressSnapshot instanceof DualSnapshotStore.StoreInProgressSnapshot storeInProgress)) {
+            return null;
+        }
+        try {
+            while (true) {
+                if (cancelChecker != null) {
+                    cancelChecker.checkCanceled();
+                }
+                return storeInProgress.publishedStableSnapshot().get(50, TimeUnit.MILLISECONDS);
+            }
+        } catch (TimeoutException e) {
+            return awaitInProgress(sourceRoot, cancelChecker);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ExecutionException e) {
+            return null;
+        }
+    }
+
+    private MaterializedStableSnapshot materialized(StableSnapshot snapshot) {
+        if (snapshot instanceof MaterializedStableSnapshot materializedSnapshot) {
+            return materializedSnapshot;
+        }
+        return null;
     }
 
     private SourceRoot reconstructSourceRoot(DomainEvent event) {
@@ -284,13 +340,13 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
         }
 
         @Override
-        public ProjectSnapshot compile(CompileTask task) throws Exception {
+        public StableSnapshot compile(CompileTask task) throws Exception {
             if (circuitOpen.get()) {
                 throw new IllegalStateException("Circuit breaker is open for " + sourceRoot);
             }
 
             try {
-                ProjectSnapshot result = baseAction.compile(task);
+                StableSnapshot result = baseAction.compile(task);
                 retryCount.set(0);
                 return result;
             } catch (Throwable e) {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
@@ -26,6 +26,7 @@ import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
@@ -278,6 +279,11 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
         }
 
         @Override
+        public ResolutionResult resolve(CompileTask task) throws Exception {
+            return baseAction.resolve(task);
+        }
+
+        @Override
         public ProjectSnapshot compile(CompileTask task) throws Exception {
             if (circuitOpen.get()) {
                 throw new IllegalStateException("Circuit breaker is open for " + sourceRoot);
@@ -296,6 +302,17 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
                     throw new RuntimeException(e);
                 }
             }
+        }
+
+        @Override
+        public LockingMode currentLockingMode(CompileTask task) {
+            return baseAction.currentLockingMode(task);
+        }
+
+        @Override
+        public CompilationPipeline.RecoveryResult recover(CompileTask task, LockingMode initialMode,
+                                                          Throwable cause) throws Exception {
+            return baseAction.recover(task, initialMode, cause);
         }
 
         boolean isOpen() {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotStore.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/DualSnapshotStore.java
@@ -111,6 +111,19 @@ public class DualSnapshotStore {
         }
     }
 
+    /**
+     * Removes all snapshot state for the given source root.
+     *
+     * @param sourceRoot the source root identity
+     */
+    public void remove(SourceRoot sourceRoot) {
+        Objects.requireNonNull(sourceRoot, "sourceRoot must not be null");
+        SnapshotPair snapshotPair = snapshots.remove(sourceRoot);
+        if (snapshotPair != null) {
+            snapshotPair.cancelInProgress();
+        }
+    }
+
     static final class StoreInProgressSnapshot implements InProgressSnapshot {
 
         private final StableSnapshot fallbackStableSnapshot;
@@ -171,6 +184,14 @@ public class DualSnapshotStore {
         void complete(StableSnapshot stableSnapshot) {
             publishedStableSnapshot.complete(stableSnapshot);
             compilationFuture.complete(stableSnapshot.compilation());
+        }
+
+        StableSnapshot fallbackStableSnapshot() {
+            return fallbackStableSnapshot;
+        }
+
+        CompletableFuture<StableSnapshot> publishedStableSnapshot() {
+            return publishedStableSnapshot;
         }
 
         void cancel() {

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/MaterializedStableSnapshot.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/MaterializedStableSnapshot.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langserver.workspace.compilerengine;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Materialized stable snapshot used by the active compiler-engine implementation.
+ *
+ * @since 1.7.0
+ */
+public final class MaterializedStableSnapshot implements StableSnapshot {
+
+    private final Map<DocumentId, SyntaxTree> syntaxTrees;
+    private final Map<Path, DocumentId> pathToDocumentIds;
+    private final Map<ModuleId, SemanticModel> semanticModels;
+    private final PackageCompilation compilation;
+    private final ContentVersion contentVersion;
+
+    /**
+     * Creates a fully materialized stable snapshot.
+     *
+     * @param syntaxTrees syntax trees keyed by document id
+     * @param pathToDocumentIds document ids keyed by normalized path
+     * @param semanticModels semantic models keyed by module id
+     * @param compilation package compilation for the snapshot
+     * @param contentVersion content version represented by the snapshot
+     */
+    public MaterializedStableSnapshot(Map<DocumentId, SyntaxTree> syntaxTrees,
+                                      Map<Path, DocumentId> pathToDocumentIds,
+                                      Map<ModuleId, SemanticModel> semanticModels,
+                                      PackageCompilation compilation,
+                                      ContentVersion contentVersion) {
+        this.syntaxTrees = Map.copyOf(Objects.requireNonNull(syntaxTrees, "syntaxTrees must not be null"));
+        this.pathToDocumentIds = Map.copyOf(Objects.requireNonNull(pathToDocumentIds,
+                "pathToDocumentIds must not be null"));
+        this.semanticModels = Map.copyOf(Objects.requireNonNull(semanticModels,
+                "semanticModels must not be null"));
+        this.compilation = Objects.requireNonNull(compilation, "compilation must not be null");
+        this.contentVersion = Objects.requireNonNull(contentVersion, "contentVersion must not be null");
+    }
+
+    @Override
+    public SyntaxTree syntaxTree(DocumentId docId) {
+        return syntaxTrees.get(docId);
+    }
+
+    @Override
+    public ContentVersion contentVersion() {
+        return contentVersion;
+    }
+
+    @Override
+    public SemanticModel semanticModel(ModuleId moduleId) {
+        return semanticModels.get(moduleId);
+    }
+
+    @Override
+    public PackageCompilation compilation() {
+        return compilation;
+    }
+
+    public SyntaxTree syntaxTree(Path filePath) {
+        DocumentId documentId = pathToDocumentIds.get(normalize(filePath));
+        return documentId == null ? null : syntaxTrees.get(documentId);
+    }
+
+    public SemanticModel semanticModel(Path filePath) {
+        DocumentId documentId = pathToDocumentIds.get(normalize(filePath));
+        return documentId == null ? null : semanticModels.get(documentId.moduleId());
+    }
+
+    private static Path normalize(Path filePath) {
+        return Objects.requireNonNull(filePath, "filePath must not be null").toAbsolutePath().normalize();
+    }
+}

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WiringConfigurationTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/WiringConfigurationTest.java
@@ -21,8 +21,9 @@ package org.ballerinalang.langserver.workspace;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.PackageCompilation;
-import org.ballerinalang.langserver.workspace.compilerengine.ProjectSnapshot;
-import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
 import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.documentstore.VirtualFileSystem;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
@@ -48,6 +49,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -79,18 +81,14 @@ public class WiringConfigurationTest {
         eventBus = new EventSyncPubSubHolder();
 
         // Create test-observable mock compilation action
-        ProjectSnapshot mockSnapshot = new ProjectSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                mock(SyntaxTree.class),
-                new ContentVersion(1)
-        );
+        StableSnapshot mockSnapshot = new MaterializedStableSnapshot(Map.of(), Map.of(), Map.of(),
+                mock(PackageCompilation.class), new ContentVersion(1));
 
         wiring = WiringConfiguration.builder()
                 .eventBus(eventBus)
                 .virtualFileSystem(new VirtualFileSystem())
                 .projectRootResolver(path -> tempDir)
-                .snapshotStore(new SnapshotStore(10))
+                .snapshotStore(new DualSnapshotStore())
                 .compilationAction(task -> mockSnapshot)
                 .projectRegistry(new ProjectRegistry(MemoryBudget.ofMb(256)))
                 .uriResolver(new UriResolver())
@@ -235,7 +233,7 @@ public class WiringConfigurationTest {
         Thread.sleep(500);
 
         // Verify CE pipeline exists (snapshot published)
-        Assert.assertTrue(wiring.snapshotStore().get(testRoot).isPresent(),
+        Assert.assertNotNull(wiring.snapshotStore().getStable(testRoot),
                 "Pipeline should exist with a snapshot before eviction");
 
         // Simulate heap pressure → WM-E2
@@ -248,7 +246,7 @@ public class WiringConfigurationTest {
         Thread.sleep(500);
 
         // CE should have cleaned up the pipeline
-        Assert.assertFalse(wiring.snapshotStore().get(testRoot).isPresent(),
+        Assert.assertNull(wiring.snapshotStore().getStable(testRoot),
                 "Chain 4: WM-E2 should cause CE to evict pipeline and clear snapshot");
     }
 

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipelineTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipelineTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
+import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -523,6 +524,165 @@ public class CompilationPipelineTest {
         Assert.assertTrue(eventReceived.await(3, TimeUnit.SECONDS),
                 "InterruptedException must be treated as cancellation and emit CE-E3");
         Assert.assertTrue(receivedKinds.contains(EventKind.COMPILER_COMPILATION_CANCELLED));
+    }
+
+    @Test
+    public void pipeline_resolutionSuccessPublishesCEE5BAndCompiles() throws InterruptedException {
+        CountDownLatch diagnosticsReady = new CountDownLatch(1);
+        CountDownLatch resolutionCalled = new CountDownLatch(1);
+        AtomicInteger compileCount = new AtomicInteger(0);
+        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+
+        eventBus = new EventSyncPubSubHolder();
+        eventBus.subscribe("test-ce-e5b", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY), event -> diagnosticsReady.countDown());
+
+        pipeline = createPipeline(eventBus, new CompilationPipeline.CompilationAction() {
+            @Override
+            public ResolutionResult resolve(CompileTask task) {
+                resolutionCalled.countDown();
+                return new ResolutionResult(task.sourceRoot(), List.of(), true);
+            }
+
+            @Override
+            public ProjectSnapshot compile(CompileTask task) {
+                compileCount.incrementAndGet();
+                return snapshot;
+            }
+        });
+
+        pipeline.requestCompilation(new ContentVersion(1));
+
+        Assert.assertTrue(resolutionCalled.await(3, TimeUnit.SECONDS));
+        Assert.assertTrue(diagnosticsReady.await(3, TimeUnit.SECONDS));
+        Assert.assertEquals(compileCount.get(), 1, "Compilation should run after successful resolution");
+    }
+
+    @Test
+    public void pipeline_nonQualifyingResolutionFailurePublishesCEE5AAndSkipsCompilation() throws InterruptedException {
+        CountDownLatch resolutionDiagnosticsReady = new CountDownLatch(1);
+        CountDownLatch compilationDiagnosticsReady = new CountDownLatch(1);
+        AtomicInteger compileCount = new AtomicInteger(0);
+
+        eventBus = new EventSyncPubSubHolder();
+        eventBus.subscribe("test-ce-e5a", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY), event -> resolutionDiagnosticsReady.countDown());
+        eventBus.subscribe("test-no-ce-e5b", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY), event -> compilationDiagnosticsReady.countDown());
+
+        pipeline = createPipeline(eventBus, new CompilationPipeline.CompilationAction() {
+            @Override
+            public ResolutionResult resolve(CompileTask task) {
+                return new ResolutionResult(task.sourceRoot(),
+                        List.of(new ResolutionResult.ResolutionDiagnostic(ResolutionResult.Severity.ERROR,
+                                "syntax error", "/tmp/project/main.bal")), false);
+            }
+
+            @Override
+            public ProjectSnapshot compile(CompileTask task) {
+                compileCount.incrementAndGet();
+                return createMockSnapshot(task.contentVersion());
+            }
+        });
+
+        pipeline.requestCompilation(new ContentVersion(1));
+
+        Assert.assertTrue(resolutionDiagnosticsReady.await(3, TimeUnit.SECONDS));
+        Assert.assertFalse(compilationDiagnosticsReady.await(300, TimeUnit.MILLISECONDS),
+                "Resolution failure must not publish CE-E5b");
+        Assert.assertEquals(compileCount.get(), 0, "Compilation must be skipped on non-qualifying resolution failure");
+    }
+
+    @Test
+    public void pipeline_birCompilationFailurePublishesRecoveredAndRecompiles() throws InterruptedException {
+        CountDownLatch recovered = new CountDownLatch(1);
+        CountDownLatch diagnosticsReady = new CountDownLatch(1);
+        AtomicInteger compileCount = new AtomicInteger(0);
+        AtomicInteger recoveryCalls = new AtomicInteger(0);
+        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+
+        eventBus = new EventSyncPubSubHolder();
+        eventBus.subscribe("test-recovered", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_RESOLUTION_RECOVERED), event -> recovered.countDown());
+        eventBus.subscribe("test-e5b-after-recovery", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY), event -> diagnosticsReady.countDown());
+
+        pipeline = createPipeline(eventBus, new CompilationPipeline.CompilationAction() {
+            @Override
+            public ResolutionResult resolve(CompileTask task) {
+                return new ResolutionResult(task.sourceRoot(), List.of(), true);
+            }
+
+            @Override
+            public ProjectSnapshot compile(CompileTask task) {
+                if (compileCount.getAndIncrement() == 0) {
+                    throw new RuntimeException("failed to load the module foo.bir");
+                }
+                return snapshot;
+            }
+
+            @Override
+            public LockingMode currentLockingMode(CompileTask task) {
+                return LockingMode.LOCKED;
+            }
+
+            @Override
+            public CompilationPipeline.RecoveryResult recover(CompileTask task, LockingMode initialMode, Throwable cause) {
+                recoveryCalls.incrementAndGet();
+                return CompilationPipeline.RecoveryResult.success();
+            }
+        });
+
+        pipeline.requestCompilation(new ContentVersion(1));
+
+        Assert.assertTrue(recovered.await(3, TimeUnit.SECONDS), "BIR failure should publish recovery event");
+        Assert.assertTrue(diagnosticsReady.await(3, TimeUnit.SECONDS),
+                "Recovered pipeline should trigger a new successful compilation cycle");
+        Assert.assertEquals(recoveryCalls.get(), 1, "Recovery ladder should be invoked once");
+        Assert.assertTrue(compileCount.get() >= 2, "Compilation should be retried after recovery");
+    }
+
+    @Test
+    public void pipeline_birCompilationFailurePublishesExhaustedWhenRecoveryFails() throws InterruptedException {
+        CountDownLatch exhausted = new CountDownLatch(1);
+        CountDownLatch diagnosticsReady = new CountDownLatch(1);
+        AtomicInteger recoveryCalls = new AtomicInteger(0);
+
+        eventBus = new EventSyncPubSubHolder();
+        eventBus.subscribe("test-exhausted", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_RESOLUTION_EXHAUSTED), event -> exhausted.countDown());
+        eventBus.subscribe("test-no-e5b-after-exhausted", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY), event -> diagnosticsReady.countDown());
+
+        pipeline = createPipeline(eventBus, new CompilationPipeline.CompilationAction() {
+            @Override
+            public ResolutionResult resolve(CompileTask task) {
+                return new ResolutionResult(task.sourceRoot(), List.of(), true);
+            }
+
+            @Override
+            public ProjectSnapshot compile(CompileTask task) {
+                throw new RuntimeException("failed to load the module bar.bir");
+            }
+
+            @Override
+            public LockingMode currentLockingMode(CompileTask task) {
+                return LockingMode.HARD;
+            }
+
+            @Override
+            public CompilationPipeline.RecoveryResult recover(CompileTask task, LockingMode initialMode, Throwable cause) {
+                recoveryCalls.incrementAndGet();
+                return CompilationPipeline.RecoveryResult.exhausted();
+            }
+        });
+
+        pipeline.requestCompilation(new ContentVersion(1));
+
+        Assert.assertTrue(exhausted.await(3, TimeUnit.SECONDS), "BIR failure should publish exhaustion event");
+        Assert.assertFalse(diagnosticsReady.await(300, TimeUnit.MILLISECONDS),
+                "Exhausted recovery must not publish CE-E5b");
+        Assert.assertEquals(recoveryCalls.get(), 1, "Recovery ladder should be invoked once");
     }
 
     // ---- Helpers ----

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipelineTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipelineTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -198,7 +199,7 @@ public class CompilationPipelineTest {
         CountDownLatch done = new CountDownLatch(1);
         List<ContentVersion> compiledVersions = Collections.synchronizedList(new ArrayList<>());
         // Pre-create snapshot on test thread to avoid Mockito issues on worker thread
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(5));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(5));
 
         pipeline = createPipeline(task -> {
             compileCount.incrementAndGet();
@@ -221,7 +222,7 @@ public class CompilationPipelineTest {
     @Test
     public void pipeline_lifoReplacementCancelsPreviousTask() throws InterruptedException {
         CountDownLatch firstStarted = new CountDownLatch(1);
-        ProjectSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
+        StableSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
         CountDownLatch firstCancelled = new CountDownLatch(1);
         CountDownLatch allDone = new CountDownLatch(1);
 
@@ -257,9 +258,9 @@ public class CompilationPipelineTest {
 
     @Test
     public void pipeline_publishesSnapshotOnSuccess() throws InterruptedException {
-        SnapshotStore store = new SnapshotStore(10);
+        DualSnapshotStore store = new DualSnapshotStore();
         CountDownLatch done = new CountDownLatch(1);
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         pipeline = createPipeline(store, task -> {
             done.countDown();
@@ -269,14 +270,14 @@ public class CompilationPipelineTest {
         pipeline.requestCompilation(new ContentVersion(1));
         Assert.assertTrue(done.await(3, TimeUnit.SECONDS));
         Thread.sleep(200);
-        Assert.assertTrue(store.get(testSourceRoot()).isPresent());
+        Assert.assertNotNull(store.getStable(testSourceRoot()));
     }
 
     @Test
     public void pipeline_emitsCEE1OnSuccessfulPublish() throws InterruptedException {
         CountDownLatch eventReceived = new CountDownLatch(1);
         List<EventKind> receivedKinds = Collections.synchronizedList(new ArrayList<>());
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         eventBus = new EventSyncPubSubHolder();
         eventBus.subscribe("test-sub", SubscriberTier.CRITICAL,
@@ -336,12 +337,12 @@ public class CompilationPipelineTest {
 
     @Test
     public void pipeline_staleVersionNotPublished() throws InterruptedException {
-        SnapshotStore store = new SnapshotStore(10);
+        DualSnapshotStore store = new DualSnapshotStore();
         CountDownLatch v1Started = new CountDownLatch(1);
         CountDownLatch v2Requested = new CountDownLatch(1);
         CountDownLatch v1Done = new CountDownLatch(1);
-        ProjectSnapshot snap1 = createMockSnapshot(new ContentVersion(1));
-        ProjectSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
+        StableSnapshot snap1 = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
 
         pipeline = createPipeline(store, task -> {
             if (task.contentVersion().equals(new ContentVersion(1))) {
@@ -363,9 +364,9 @@ public class CompilationPipelineTest {
         Assert.assertTrue(v1Done.await(3, TimeUnit.SECONDS));
         Thread.sleep(500);
 
-        var snap = store.get(testSourceRoot());
-        if (snap.isPresent()) {
-            Assert.assertNotEquals(snap.get().contentVersion(), new ContentVersion(1),
+        StableSnapshot snap = store.getStable(testSourceRoot());
+        if (snap != null) {
+            Assert.assertNotEquals(snap.contentVersion(), new ContentVersion(1),
                     "Stale version 1 should not be published");
         }
     }
@@ -374,7 +375,7 @@ public class CompilationPipelineTest {
     public void pipeline_closeStopsAllWork() throws InterruptedException {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch proceed = new CountDownLatch(1);
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         pipeline = createPipeline(task -> {
             started.countDown();
@@ -397,7 +398,7 @@ public class CompilationPipelineTest {
 
     @Test
     public void pipeline_closeIsIdempotent() {
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
         pipeline = createPipeline(task -> snapshot);
         pipeline.close();
         pipeline.close(); // should not throw
@@ -407,7 +408,7 @@ public class CompilationPipelineTest {
     public void pipeline_isCompilingReflectsState() throws InterruptedException {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch proceed = new CountDownLatch(1);
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         pipeline = createPipeline(task -> {
             started.countDown();
@@ -430,7 +431,7 @@ public class CompilationPipelineTest {
     public void pipeline_rejectsNullSourceRoot() {
         EventSyncPubSubHolder bus = new EventSyncPubSubHolder();
         try {
-            new CompilationPipeline(null, new SnapshotStore(10), bus,
+            new CompilationPipeline(null, new DualSnapshotStore(), bus,
                     task -> createMockSnapshot(task.contentVersion()));
         } finally {
             bus.close();
@@ -439,7 +440,7 @@ public class CompilationPipelineTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void pipeline_rejectsNullContentVersion() {
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
         pipeline = createPipeline(task -> snapshot);
         pipeline.requestCompilation(null);
     }
@@ -448,7 +449,7 @@ public class CompilationPipelineTest {
     public void pipeline_interruptsActiveWorkerOnSupersedingRequest() throws InterruptedException {
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch interrupted = new CountDownLatch(1);
-        ProjectSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
+        StableSnapshot snap2 = createMockSnapshot(new ContentVersion(2));
 
         pipeline = createPipeline(task -> {
             if (task.contentVersion().equals(new ContentVersion(1))) {
@@ -486,7 +487,7 @@ public class CompilationPipelineTest {
                     cancellationEvent.countDown();
                 });
 
-        pipeline = new CompilationPipeline(testSourceRoot(), new SnapshotStore(10), eventBus, task -> {
+        pipeline = new CompilationPipeline(testSourceRoot(), new DualSnapshotStore(), eventBus, task -> {
             if (task.contentVersion().equals(new ContentVersion(1))) {
                 firstStarted.countDown();
                 releaseCancelledTask.await(5, TimeUnit.SECONDS);
@@ -516,7 +517,7 @@ public class CompilationPipelineTest {
                     eventReceived.countDown();
                 });
 
-        pipeline = new CompilationPipeline(testSourceRoot(), new SnapshotStore(10), eventBus, task -> {
+        pipeline = new CompilationPipeline(testSourceRoot(), new DualSnapshotStore(), eventBus, task -> {
             throw new InterruptedException("Thread interrupted during compilation");
         });
 
@@ -531,7 +532,7 @@ public class CompilationPipelineTest {
         CountDownLatch diagnosticsReady = new CountDownLatch(1);
         CountDownLatch resolutionCalled = new CountDownLatch(1);
         AtomicInteger compileCount = new AtomicInteger(0);
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         eventBus = new EventSyncPubSubHolder();
         eventBus.subscribe("test-ce-e5b", SubscriberTier.CRITICAL,
@@ -545,7 +546,7 @@ public class CompilationPipelineTest {
             }
 
             @Override
-            public ProjectSnapshot compile(CompileTask task) {
+            public StableSnapshot compile(CompileTask task) {
                 compileCount.incrementAndGet();
                 return snapshot;
             }
@@ -579,7 +580,7 @@ public class CompilationPipelineTest {
             }
 
             @Override
-            public ProjectSnapshot compile(CompileTask task) {
+            public StableSnapshot compile(CompileTask task) {
                 compileCount.incrementAndGet();
                 return createMockSnapshot(task.contentVersion());
             }
@@ -599,7 +600,7 @@ public class CompilationPipelineTest {
         CountDownLatch diagnosticsReady = new CountDownLatch(1);
         AtomicInteger compileCount = new AtomicInteger(0);
         AtomicInteger recoveryCalls = new AtomicInteger(0);
-        ProjectSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createMockSnapshot(new ContentVersion(1));
 
         eventBus = new EventSyncPubSubHolder();
         eventBus.subscribe("test-recovered", SubscriberTier.CRITICAL,
@@ -614,7 +615,7 @@ public class CompilationPipelineTest {
             }
 
             @Override
-            public ProjectSnapshot compile(CompileTask task) {
+            public StableSnapshot compile(CompileTask task) {
                 if (compileCount.getAndIncrement() == 0) {
                     throw new RuntimeException("failed to load the module foo.bir");
                 }
@@ -661,7 +662,7 @@ public class CompilationPipelineTest {
             }
 
             @Override
-            public ProjectSnapshot compile(CompileTask task) {
+            public StableSnapshot compile(CompileTask task) {
                 throw new RuntimeException("failed to load the module bar.bir");
             }
 
@@ -697,10 +698,10 @@ public class CompilationPipelineTest {
 
     private CompilationPipeline createPipeline(CompilationPipeline.CompilationAction action) {
         eventBus = new EventSyncPubSubHolder();
-        return new CompilationPipeline(testSourceRoot(), new SnapshotStore(10), eventBus, action);
+        return new CompilationPipeline(testSourceRoot(), new DualSnapshotStore(), eventBus, action);
     }
 
-    private CompilationPipeline createPipeline(SnapshotStore store,
+    private CompilationPipeline createPipeline(DualSnapshotStore store,
                                                CompilationPipeline.CompilationAction action) {
         eventBus = new EventSyncPubSubHolder();
         return new CompilationPipeline(testSourceRoot(), store, eventBus, action);
@@ -709,15 +710,11 @@ public class CompilationPipelineTest {
     private CompilationPipeline createPipeline(EventSyncPubSubHolder bus,
                                                CompilationPipeline.CompilationAction action) {
         this.eventBus = bus;
-        return new CompilationPipeline(testSourceRoot(), new SnapshotStore(10), bus, action);
+        return new CompilationPipeline(testSourceRoot(), new DualSnapshotStore(), bus, action);
     }
 
-    private static ProjectSnapshot createMockSnapshot(ContentVersion version) {
-        return new ProjectSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                mock(SyntaxTree.class),
-                version
-        );
+    private static StableSnapshot createMockSnapshot(ContentVersion version) {
+        return new MaterializedStableSnapshot(Map.of(), Map.of(), Map.of(),
+                mock(PackageCompilation.class), version);
     }
 }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
@@ -20,6 +20,8 @@ package org.ballerinalang.langserver.workspace.compilerengine;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.PackageCompilation;
 import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
@@ -37,12 +39,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for CompilationServiceImpl covering event routing, circuit breaker, and LSP query methods.
@@ -53,22 +57,18 @@ public class CompilationServiceImplTest {
 
     private CompilationServiceImpl service;
     private EventSyncPubSubHolder eventBus;
-    private SnapshotStore snapshotStore;
-    private ProjectSnapshot mockSnapshot;
+    private DualSnapshotStore snapshotStore;
+    private StableSnapshot mockSnapshot;
     private static final SourceRoot TEST_ROOT = new SourceRoot(
             Path.of("/tmp/test-project").toAbsolutePath().normalize());
 
     @BeforeMethod
     public void setUp() {
         eventBus = new EventSyncPubSubHolder();
-        snapshotStore = new SnapshotStore(10);
+        snapshotStore = new DualSnapshotStore();
         // Pre-create mock snapshot to avoid Mockito initialization issues across tests
-        mockSnapshot = new ProjectSnapshot(
-                mock(PackageCompilation.class),
-                mock(SemanticModel.class),
-                mock(SyntaxTree.class),
-                new ContentVersion(1)
-        );
+        mockSnapshot = createStableSnapshot(mock(SyntaxTree.class), mock(SemanticModel.class),
+                mock(PackageCompilation.class), new ContentVersion(1));
     }
 
     @AfterMethod
@@ -88,7 +88,7 @@ public class CompilationServiceImplTest {
     // ---- Constructor & Null Checks ----
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void service_constructor_rejectsNullSnapshotStore() {
+    public void service_constructor_rejectsNullDualSnapshotStore() {
         new CompilationServiceImpl(null, eventBus, task -> mockSnapshot);
     }
 
@@ -131,13 +131,13 @@ public class CompilationServiceImplTest {
         Thread.sleep(200);
 
         // Verify pipeline exists
-        Assert.assertTrue(snapshotStore.get(TEST_ROOT).isPresent(), "Snapshot should exist");
+        Assert.assertNotNull(snapshotStore.getStable(TEST_ROOT), "Snapshot should exist");
 
         publishWmE2(TEST_ROOT);
         Thread.sleep(200);
 
         // Verify pipeline is evicted
-        Assert.assertFalse(snapshotStore.get(TEST_ROOT).isPresent(),
+        Assert.assertNull(snapshotStore.getStable(TEST_ROOT),
                 "WM-E2 should evict pipeline and snapshot");
     }
 
@@ -260,8 +260,8 @@ public class CompilationServiceImplTest {
     public void service_syntaxTree_returnsTreeWhenSnapshotExists() throws InterruptedException {
         CountDownLatch compiled = new CountDownLatch(1);
         SyntaxTree mockTree = mock(SyntaxTree.class);
-        ProjectSnapshot snapshot = new ProjectSnapshot(mock(PackageCompilation.class),
-                mock(SemanticModel.class), mockTree, new ContentVersion(1));
+        StableSnapshot snapshot = createStableSnapshot(mockTree, mock(SemanticModel.class),
+                mock(PackageCompilation.class), new ContentVersion(1));
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             compiled.countDown();
             return snapshot;
@@ -288,8 +288,8 @@ public class CompilationServiceImplTest {
     public void service_semanticModel_returnsModelWhenSnapshotExists() throws InterruptedException {
         CountDownLatch compiled = new CountDownLatch(1);
         SemanticModel mockModel = mock(SemanticModel.class);
-        ProjectSnapshot snapshot = new ProjectSnapshot(mock(PackageCompilation.class),
-                mockModel, mock(SyntaxTree.class), new ContentVersion(1));
+        StableSnapshot snapshot = createStableSnapshot(mock(SyntaxTree.class), mockModel,
+                mock(PackageCompilation.class), new ContentVersion(1));
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             compiled.countDown();
             return snapshot;
@@ -316,8 +316,8 @@ public class CompilationServiceImplTest {
     public void service_compilation_returnsCompilationWhenSnapshotExists() throws InterruptedException {
         CountDownLatch compiled = new CountDownLatch(1);
         PackageCompilation mockCompilation = mock(PackageCompilation.class);
-        ProjectSnapshot snapshot = new ProjectSnapshot(mockCompilation,
-                mock(SemanticModel.class), mock(SyntaxTree.class), new ContentVersion(1));
+        StableSnapshot snapshot = createStableSnapshot(mock(SyntaxTree.class), mock(SemanticModel.class),
+                mockCompilation, new ContentVersion(1));
         service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
             compiled.countDown();
             return snapshot;
@@ -468,6 +468,16 @@ public class CompilationServiceImplTest {
         eventBus.publish(new DomainEvent(Instant.now(), sr.path().toString(),
                 EventKind.WM_FILE_WATCHED_CHANGED,
                 sr.path().resolve("Dependencies.toml") + "|" + scope + "|Changed"));
+    }
+
+    private StableSnapshot createStableSnapshot(SyntaxTree syntaxTree, SemanticModel semanticModel,
+                                                PackageCompilation compilation, ContentVersion version) {
+        DocumentId documentId = mock(DocumentId.class);
+        ModuleId moduleId = mock(ModuleId.class);
+        when(documentId.moduleId()).thenReturn(moduleId);
+        return new MaterializedStableSnapshot(Map.of(documentId, syntaxTree),
+                Map.of(TEST_ROOT.path().resolve("main.bal").normalize(), documentId),
+                Map.of(moduleId, semanticModel), compilation, version);
     }
 
 }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/AsyncCompilationPipelineTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/AsyncCompilationPipelineTest.java
@@ -25,8 +25,9 @@ import org.ballerinalang.langserver.workspace.compilerengine.CancellationToken;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPhase;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
 import org.ballerinalang.langserver.workspace.compilerengine.CompileTask;
-import org.ballerinalang.langserver.workspace.compilerengine.ProjectSnapshot;
-import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
 import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.lspgateway.TwoTierReadinessController;
@@ -85,9 +86,9 @@ public class AsyncCompilationPipelineTest {
         CountDownLatch compiled = new CountDownLatch(1);
         AtomicReference<String> compilationThreadName = new AtomicReference<>();
         String requestThreadName = "lsp-request-1";
-        ProjectSnapshot snapshot = createSnapshot(new ContentVersion(1));
+        StableSnapshot snapshot = createSnapshot(new ContentVersion(1));
 
-        pipeline = createPipeline(new SnapshotStore(4), task -> {
+        pipeline = createPipeline(new DualSnapshotStore(), task -> {
             compilationThreadName.set(Thread.currentThread().getName());
             compiled.countDown();
             return snapshot;
@@ -112,9 +113,9 @@ public class AsyncCompilationPipelineTest {
         CountDownLatch releaseFirst = new CountDownLatch(1);
         CountDownLatch latestExecuted = new CountDownLatch(1);
         List<Integer> executedVersions = new CopyOnWriteArrayList<>();
-        ProjectSnapshot latestSnapshot = createSnapshot(new ContentVersion(3));
+        StableSnapshot latestSnapshot = createSnapshot(new ContentVersion(3));
 
-        pipeline = createPipeline(new SnapshotStore(4), task -> {
+        pipeline = createPipeline(new DualSnapshotStore(), task -> {
             int version = task.contentVersion().value();
             if (version == 1) {
                 firstStarted.countDown();
@@ -143,16 +144,16 @@ public class AsyncCompilationPipelineTest {
      * Verifies successful compilation publishes an immutable snapshot to the snapshot store.
      */
     @Test
-    public void successfulCompilation_publishesSnapshotToSnapshotStore() {
-        SnapshotStore snapshotStore = new SnapshotStore(4);
-        ProjectSnapshot expectedSnapshot = createSnapshot(new ContentVersion(42));
+    public void successfulCompilation_publishesSnapshotToDualSnapshotStore() {
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
+        StableSnapshot expectedSnapshot = createSnapshot(new ContentVersion(42));
 
         pipeline = createPipeline(snapshotStore, task -> expectedSnapshot);
         pipeline.requestCompilation(new ContentVersion(42));
 
         Awaitility.await().atMost(3, TimeUnit.SECONDS)
-                .until(() -> snapshotStore.get(TEST_ROOT).isPresent());
-        Assert.assertSame(snapshotStore.get(TEST_ROOT).orElseThrow(), expectedSnapshot,
+                .until(() -> snapshotStore.getStable(TEST_ROOT) != null);
+        Assert.assertSame(snapshotStore.getStable(TEST_ROOT), expectedSnapshot,
                 "Successful compilation must publish the completed snapshot atomically");
     }
 
@@ -161,11 +162,11 @@ public class AsyncCompilationPipelineTest {
      */
     @Test
     public void staleCompilationResult_isDiscardedInFavorOfLatestVersion() throws Exception {
-        SnapshotStore snapshotStore = new SnapshotStore(4);
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
         CountDownLatch oldVersionStarted = new CountDownLatch(1);
         CountDownLatch releaseOldVersion = new CountDownLatch(1);
         CountDownLatch latestPublished = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 10, createSnapshot(new ContentVersion(10)),
                 11, createSnapshot(new ContentVersion(11))
         );
@@ -188,7 +189,7 @@ public class AsyncCompilationPipelineTest {
 
         Assert.assertTrue(latestPublished.await(3, TimeUnit.SECONDS), "Latest compilation never completed");
         Awaitility.await().atMost(3, TimeUnit.SECONDS)
-                .untilAsserted(() -> Assert.assertEquals(snapshotStore.get(TEST_ROOT).orElseThrow().contentVersion(),
+                .untilAsserted(() -> Assert.assertEquals(snapshotStore.getStable(TEST_ROOT).contentVersion(),
                         new ContentVersion(11), "Only the latest content version may remain published"));
     }
 
@@ -214,9 +215,9 @@ public class AsyncCompilationPipelineTest {
     @Test
     public void rapidTypingWithinDebounceWindow_coalescesToSingleCompilation() {
         AtomicInteger compileCount = new AtomicInteger();
-        ProjectSnapshot latestSnapshot = createSnapshot(new ContentVersion(10));
+        StableSnapshot latestSnapshot = createSnapshot(new ContentVersion(10));
 
-        pipeline = createPipeline(new SnapshotStore(4), task -> {
+        pipeline = createPipeline(new DualSnapshotStore(), task -> {
             compileCount.incrementAndGet();
             return latestSnapshot;
         });
@@ -249,18 +250,14 @@ public class AsyncCompilationPipelineTest {
                 () -> task.advancePhase(CompilationPhase.POST_PARSE));
     }
 
-    private CompilationPipeline createPipeline(SnapshotStore snapshotStore,
+    private CompilationPipeline createPipeline(DualSnapshotStore snapshotStore,
                                                CompilationPipeline.CompilationAction action) {
         eventBus = new EventSyncPubSubHolder();
         return new CompilationPipeline(TEST_ROOT, snapshotStore, eventBus, action);
     }
 
-    private static ProjectSnapshot createSnapshot(ContentVersion version) {
-        return new ProjectSnapshot(
-                Mockito.mock(PackageCompilation.class),
-                Mockito.mock(SemanticModel.class),
-                Mockito.mock(SyntaxTree.class),
-                version
-        );
+    private static StableSnapshot createSnapshot(ContentVersion version) {
+        return new MaterializedStableSnapshot(Map.of(), Map.of(), Map.of(),
+                Mockito.mock(PackageCompilation.class), version);
     }
 }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CancellationModelTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CancellationModelTest.java
@@ -25,8 +25,9 @@ import org.ballerinalang.langserver.workspace.compilerengine.CancellationToken;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPhase;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
 import org.ballerinalang.langserver.workspace.compilerengine.CompileTask;
-import org.ballerinalang.langserver.workspace.compilerengine.ProjectSnapshot;
-import org.ballerinalang.langserver.workspace.compilerengine.SnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
 import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
@@ -81,12 +82,12 @@ public class CancellationModelTest {
     public void supersedingDidChange_interruptsInProgressCompilationThread() throws Exception {
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch interrupted = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 1, createSnapshot(new ContentVersion(1)),
                 2, createSnapshot(new ContentVersion(2))
         );
 
-        pipeline = createPipeline(new SnapshotStore(4), task -> {
+        pipeline = createPipeline(new DualSnapshotStore(), task -> {
             if (task.contentVersion().value() == 1) {
                 firstStarted.countDown();
                 try {
@@ -114,9 +115,9 @@ public class CancellationModelTest {
      */
     @Test
     public void interruptedCompilation_discardsPartialResultWithoutPublishingSnapshot() throws Exception {
-        SnapshotStore snapshotStore = new SnapshotStore(4);
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
         CountDownLatch firstStarted = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 1, createSnapshot(new ContentVersion(1)),
                 2, createSnapshot(new ContentVersion(2))
         );
@@ -139,8 +140,8 @@ public class CancellationModelTest {
         pipeline.requestCompilation(new ContentVersion(2));
 
         Awaitility.await().atMost(3, TimeUnit.SECONDS)
-                .until(() -> snapshotStore.get(TEST_ROOT).isPresent());
-        Assert.assertEquals(snapshotStore.get(TEST_ROOT).orElseThrow().contentVersion(), new ContentVersion(2),
+                .until(() -> snapshotStore.getStable(TEST_ROOT) != null);
+        Assert.assertEquals(snapshotStore.getStable(TEST_ROOT).contentVersion(), new ContentVersion(2),
                 "Interrupted compilation must never publish a partial snapshot");
     }
 
@@ -152,7 +153,7 @@ public class CancellationModelTest {
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch releaseCancelledTask = new CountDownLatch(1);
         CountDownLatch cancellationEvent = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 1, createSnapshot(new ContentVersion(1)),
                 2, createSnapshot(new ContentVersion(2))
         );
@@ -160,7 +161,7 @@ public class CancellationModelTest {
         eventBus = new EventSyncPubSubHolder();
         eventBus.subscribe("cancelled-task-listener", SubscriberTier.CRITICAL,
                 Set.of(EventKind.COMPILER_COMPILATION_CANCELLED), event -> cancellationEvent.countDown());
-        pipeline = new CompilationPipeline(TEST_ROOT, new SnapshotStore(4), eventBus, task -> {
+        pipeline = new CompilationPipeline(TEST_ROOT, new DualSnapshotStore(), eventBus, task -> {
             if (task.contentVersion().value() == 1) {
                 firstStarted.countDown();
                 releaseCancelledTask.await(5, TimeUnit.SECONDS);
@@ -182,10 +183,10 @@ public class CancellationModelTest {
      */
     @Test
     public void cancelledTask_publicationGuardPreventsStaleSnapshotOverwrite() throws Exception {
-        SnapshotStore snapshotStore = new SnapshotStore(4);
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch releaseCancelledTask = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 1, createSnapshot(new ContentVersion(1)),
                 2, createSnapshot(new ContentVersion(2))
         );
@@ -204,7 +205,7 @@ public class CancellationModelTest {
         releaseCancelledTask.countDown();
 
         Awaitility.await().atMost(3, TimeUnit.SECONDS)
-                .untilAsserted(() -> Assert.assertEquals(snapshotStore.get(TEST_ROOT).orElseThrow().contentVersion(),
+                .untilAsserted(() -> Assert.assertEquals(snapshotStore.getStable(TEST_ROOT).contentVersion(),
                         new ContentVersion(2), "Cancellation guard must prevent stale snapshots from being published"));
     }
 
@@ -231,7 +232,7 @@ public class CancellationModelTest {
         AtomicInteger maxConcurrentCompilations = new AtomicInteger();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch releaseFirst = new CountDownLatch(1);
-        Map<Integer, ProjectSnapshot> snapshots = Map.of(
+        Map<Integer, StableSnapshot> snapshots = Map.of(
                 1, createSnapshot(new ContentVersion(1)),
                 2, createSnapshot(new ContentVersion(2)),
                 3, createSnapshot(new ContentVersion(3)),
@@ -239,7 +240,7 @@ public class CancellationModelTest {
                 5, createSnapshot(new ContentVersion(5))
         );
 
-        pipeline = createPipeline(new SnapshotStore(4), task -> {
+        pipeline = createPipeline(new DualSnapshotStore(), task -> {
             int activeNow = activeCompilations.incrementAndGet();
             maxConcurrentCompilations.updateAndGet(previous -> Math.max(previous, activeNow));
             try {
@@ -280,18 +281,14 @@ public class CancellationModelTest {
         };
     }
 
-    private CompilationPipeline createPipeline(SnapshotStore snapshotStore,
+    private CompilationPipeline createPipeline(DualSnapshotStore snapshotStore,
                                                CompilationPipeline.CompilationAction action) {
         eventBus = new EventSyncPubSubHolder();
         return new CompilationPipeline(TEST_ROOT, snapshotStore, eventBus, action);
     }
 
-    private static ProjectSnapshot createSnapshot(ContentVersion version) {
-        return new ProjectSnapshot(
-                Mockito.mock(PackageCompilation.class),
-                Mockito.mock(SemanticModel.class),
-                Mockito.mock(SyntaxTree.class),
-                version
-        );
+    private static StableSnapshot createSnapshot(ContentVersion version) {
+        return new MaterializedStableSnapshot(Map.of(), Map.of(), Map.of(),
+                Mockito.mock(PackageCompilation.class), version);
     }
 }


### PR DESCRIPTION
## Purpose

Add a resolution-first compilation flow so the workspace compiler emits ADR-049 diagnostics events, skips compilation on non-qualifying resolution failures, and retries BIR-style compilation failures through the transient recovery ladder.

## Approach

Extended the compilation pipeline with a resolution phase ahead of compilation, plus explicit event emission for resolution success/failure and recovery outcomes. Wired the production compilation action to resolve with the current locking mode, detect BIR compilation failures, and retry using progressively more permissive transient locking modes without mutating project config.

## What Was Fixed / Changed

- Resolution now runs before compilation.
- Non-qualifying resolution failures emit `CE-E5a` and stop before compile.
- Successful resolution emits `CE-E5b` after compilation completes.
- BIR-style compilation failures trigger transient recovery attempts.
- Recovery success emits `CE_RESOLUTION_RECOVERED`; exhaustion emits `CE_RESOLUTION_EXHAUSTED`.
- The configured locking mode remains unchanged during recovery.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/`
- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/`

## How Has This Been Tested

- Ran `./gradlew :langserver-core:test --tests org.ballerinalang.langserver.workspace.compilerengine.CompilationPipelineTest`
- Ran `./gradlew :langserver-core:test --tests org.ballerinalang.langserver.workspace.compilerengine.CompilationServiceImplTest --tests org.ballerinalang.langserver.workspace.compilerengine.CompilationPipelineTest`
- Ran `./gradlew :langserver-core:test` to verify the broader suite still exposes the same pre-existing unrelated failures

## Remarks & Notes

- Recovery is triggered by BIR-style compilation failures (`failed to load the module ...bir`).
- The broader `:langserver-core:test` suite still has unrelated pre-existing failures in definition/expression-scheme tests.
