### PR TITLE
Preserve replacement in-progress snapshots

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationPipeline.java
@@ -181,6 +181,7 @@ public class CompilationPipeline implements AutoCloseable {
         if (inflight != null) {
             inflight.cancel();
         }
+        snapshotStore.cancelInProgress(sourceRoot);
         debounceScheduler.shutdownNow();
         compilationWorker.shutdownNow();
     }
@@ -207,13 +208,13 @@ public class CompilationPipeline implements AutoCloseable {
 
         CancellationToken token = new CancellationToken();
         CompileTask task = new CompileTask(sourceRoot, contentVersion, token);
-        snapshotStore.startCompilation(sourceRoot);
+        InProgressSnapshot inProgressSnapshot = snapshotStore.startCompilation(sourceRoot);
         inflightTask.set(task);
 
-        compilationWorker.submit(() -> executeCompilation(task));
+        compilationWorker.submit(() -> executeCompilation(task, inProgressSnapshot));
     }
 
-    private void executeCompilation(CompileTask task) {
+    private void executeCompilation(CompileTask task, InProgressSnapshot inProgressSnapshot) {
         activeWorkerThread.set(Thread.currentThread());
         boolean published = false;
         try {
@@ -259,7 +260,7 @@ public class CompilationPipeline implements AutoCloseable {
             LOG.log(Level.WARNING, "Compilation failed for " + sourceRoot, e);
             emitEvent(EventKind.COMPILER_COMPILATION_FAILED);
         } finally {
-            if (!published) {
+            if (!published && snapshotStore.getInProgress(sourceRoot) == inProgressSnapshot) {
                 snapshotStore.cancelInProgress(sourceRoot);
             }
             activeWorkerThread.compareAndSet(Thread.currentThread(), null);

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CancellationModelTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CancellationModelTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.workspace.compilerengine.CancellationToken;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPhase;
 import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
 import org.ballerinalang.langserver.workspace.compilerengine.CompileTask;
+import org.ballerinalang.langserver.workspace.compilerengine.InProgressSnapshot;
 import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
 import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
 import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
@@ -207,6 +208,56 @@ public class CancellationModelTest {
         Awaitility.await().atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assert.assertEquals(snapshotStore.getStable(TEST_ROOT).contentVersion(),
                         new ContentVersion(2), "Cancellation guard must prevent stale snapshots from being published"));
+    }
+
+    /**
+     * Verifies a superseded compilation does not cancel the replacement in-progress snapshot.
+     */
+    @Test
+    public void supersededCompilation_keepsReplacementInProgressSnapshotVisibleUntilPublish() throws Exception {
+        DualSnapshotStore snapshotStore = new DualSnapshotStore();
+        StableSnapshot previousSnapshot = createSnapshot(new ContentVersion(0));
+        StableSnapshot replacementSnapshot = createSnapshot(new ContentVersion(2));
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch replacementStarted = new CountDownLatch(1);
+        CountDownLatch releaseReplacement = new CountDownLatch(1);
+        snapshotStore.publishStable(TEST_ROOT, previousSnapshot);
+
+        pipeline = createPipeline(snapshotStore, task -> {
+            if (task.contentVersion().value() == 1) {
+                firstStarted.countDown();
+                try {
+                    new CountDownLatch(1).await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new CancellationException("interrupted");
+                }
+                throw new AssertionError("Superseded compilation should be interrupted");
+            }
+            replacementStarted.countDown();
+            releaseReplacement.await(5, TimeUnit.SECONDS);
+            return replacementSnapshot;
+        });
+
+        pipeline.requestCompilation(new ContentVersion(1));
+        Assert.assertTrue(firstStarted.await(3, TimeUnit.SECONDS), "Initial compilation did not start");
+
+        pipeline.requestCompilation(new ContentVersion(2));
+        Assert.assertTrue(replacementStarted.await(3, TimeUnit.SECONDS), "Replacement compilation did not start");
+
+        Assert.assertSame(snapshotStore.getStable(TEST_ROOT), previousSnapshot,
+                "Consumers calling getStable() during replacement compilation must still see the last published snapshot");
+        InProgressSnapshot inProgressSnapshot = snapshotStore.getInProgress(TEST_ROOT);
+        Assert.assertNotNull(inProgressSnapshot,
+                "Replacement compilation must remain visible through getInProgress() until it publishes");
+        Assert.assertFalse(inProgressSnapshot.compilation(() -> {
+        }).isDone(), "Replacement in-progress compilation future must stay pending while compilation is running");
+
+        releaseReplacement.countDown();
+
+        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assert.assertEquals(snapshotStore.getStable(TEST_ROOT).contentVersion(),
+                        new ContentVersion(2), "Replacement compilation must publish the new stable snapshot"));
     }
 
     /**


### PR DESCRIPTION
## Purpose

Prevent a superseded compilation from cancelling the replacement
`InProgressSnapshot` in `CompilationPipeline`, which could hide the active
compile from readers before the new stable snapshot was published.

## Approach

Capture the specific `InProgressSnapshot` created for each compilation cycle
and only cancel it during cleanup if it is still the active store entry. Also
cancel any remaining in-progress snapshot when the pipeline closes. Add an
acceptance test that reproduces a superseding compile and verifies stable and
in-progress visibility throughout the lifecycle.

## What Was Fixed / Changed

- Preserve the replacement in-progress snapshot when an older compilation exits
- Keep `getStable()` pinned to the previously published snapshot during the
  replacement compile
- Keep `getInProgress()` visible and pending until the replacement snapshot is
  published
- Clear owned in-progress snapshot state when the pipeline shuts down

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance`

## How Has This Been Tested

- `./gradlew :langserver-core:test --tests "org.ballerinalang.langserver.workspace.test.acceptance.CancellationModelTest.supersededCompilation_keepsReplacementInProgressSnapshotVisibleUntilPublish"`
- `./gradlew :langserver-core:test --tests "org.ballerinalang.langserver.workspace.compilerengine.CompilationPipelineTest" --tests "org.ballerinalang.langserver.workspace.test.acceptance.AsyncCompilationPipelineTest" --tests "org.ballerinalang.langserver.workspace.test.acceptance.CancellationModelTest"`

## Remarks & Notes

- No `DualSnapshotStore` implementation changes were required
- No TODOs or FIXMEs were introduced
