### PR TITLE
Implement ChangeApplier and absorb document lifecycle into ProjectService

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/WiringConfiguration.java
@@ -31,6 +31,7 @@ import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.execution.ExecutionServiceImpl;
 import org.ballerinalang.langserver.workspace.execution.GracePeriod;
 import org.ballerinalang.langserver.workspace.observability.WorkspaceTraceLogger;
+import org.ballerinalang.langserver.workspace.workspacemanager.ChangeBuffer;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectLoader;
 import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
@@ -82,7 +83,8 @@ public final class WiringConfiguration implements AutoCloseable {
         // 2. ProjectService (subscribes to DS-E1, DS-E3, CE-E2, CE-E5;
         //    internally creates LockingModeController which subscribes to CE-E6, CE-E4)
         this.projectService = new ProjectServiceImpl(
-                builder.projectRegistry, builder.uriResolver, eventBus, builder.projectLoader);
+                builder.projectRegistry, builder.uriResolver, eventBus, builder.projectLoader,
+                new ChangeBuffer());
 
         // 3. CompilationService (subscribes to WM-E1, WM-E2, WM-E4, DS-E2, DS-E4)
         this.compilationService = new CompilationServiceImpl(

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectService.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectService.java
@@ -20,10 +20,14 @@ package org.ballerinalang.langserver.workspace.workspacemanager;
 
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Project context service contract.
@@ -96,4 +100,48 @@ public interface ProjectService {
      * @param filePath a file path within the project to evict
      */
     void evictProject(Path filePath);
+
+    /**
+     * Signals that a document has been opened in the editor (WM-E8).
+     *
+     * <p>Creates an EDITOR-layer entry in the {@link ChangeBuffer} for the given URI (which
+     * is the open/closed signal per ADR-047 §6) and publishes a
+     * {@code WM_DOCUMENT_OPENED} event.
+     *
+     * @param uri     the document URI; must not be null
+     * @param content the initial full-text content; must not be null
+     */
+    void didOpen(DocumentUri uri, String content);
+
+    /**
+     * Signals that the content of an open document has changed (WM-E9).
+     *
+     * <p>Appends each change to the EDITOR layer of the {@link ChangeBuffer} for the
+     * given URI and publishes a {@code WM_DOCUMENT_CHANGED} event.
+     *
+     * @param uri     the document URI; must not be null
+     * @param changes ordered list of LSP content-change events; must not be null or empty
+     */
+    void didChange(DocumentUri uri, List<TextDocumentContentChangeEvent> changes);
+
+    /**
+     * Signals that a document has been closed in the editor (WM-E10).
+     *
+     * <p>Clears all EDITOR-layer buffered changes for the URI (removing the open marker
+     * per ADR-047 §6) and publishes a {@code WM_DOCUMENT_CLOSED} event.
+     *
+     * @param uri the document URI; must not be null
+     */
+    void didClose(DocumentUri uri);
+
+    /**
+     * Signals that one or more watched files have changed on the file system (WM-E11).
+     *
+     * <p>Routes each {@link FileEvent} to the {@link ChangeBuffer} (deferred if the
+     * document is open, immediate if closed) and publishes a
+     * {@code WM_FILE_WATCHED_CHANGED} event for each affected URI.
+     *
+     * @param events the list of file-watcher events; must not be null
+     */
+    void didChangeWatchedFiles(List<FileEvent> events);
 }

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
@@ -22,12 +22,15 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
 import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
 import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 import java.net.URI;
@@ -42,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Service layer implementation managing workspace projects.
@@ -74,7 +78,10 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private final UriResolver uriResolver;
     private final EventSyncPubSubHolder eventBus;
     private final ProjectLoader loader;
+    private final ChangeBuffer changeBuffer;
     private final ConcurrentHashMap<SourceRoot, Project> ballerinaProjects;
+    /** Per-URI monotonically increasing version counter for EDITOR-layer buffered changes. */
+    private final ConcurrentHashMap<DocumentUri, AtomicInteger> versionCounters;
 
     /**
      * Constructs a project service with full wiring of dependencies.
@@ -91,20 +98,25 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
      * @param uriResolver URI resolver for lock-free path resolution; must not be null
      * @param eventBus event bus; must not be null
      * @param loader Ballerina project loader; must not be null
+     * @param changeBuffer per-URI, per-layer change buffer; must not be null
      * @throws NullPointerException if any argument is null
      */
     public ProjectServiceImpl(ProjectRegistry registry, UriResolver uriResolver,
-                              EventSyncPubSubHolder eventBus, ProjectLoader loader) {
+                              EventSyncPubSubHolder eventBus, ProjectLoader loader,
+                              ChangeBuffer changeBuffer) {
         Objects.requireNonNull(registry, "registry must not be null");
         Objects.requireNonNull(uriResolver, "uriResolver must not be null");
         Objects.requireNonNull(eventBus, "eventBus must not be null");
         Objects.requireNonNull(loader, "loader must not be null");
+        Objects.requireNonNull(changeBuffer, "changeBuffer must not be null");
 
         this.registry = registry;
         this.uriResolver = uriResolver;
         this.eventBus = eventBus;
         this.loader = loader;
+        this.changeBuffer = changeBuffer;
         this.ballerinaProjects = new ConcurrentHashMap<>();
+        this.versionCounters = new ConcurrentHashMap<>();
 
         // 1. Wire self as registry listener for eviction and batch events
         registry.addListener(this);
@@ -437,6 +449,62 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         }
     }
 
+    // =========================================================================
+    // Document Lifecycle Methods (T-044: absorb DocumentService into ProjectService)
+    // =========================================================================
+
+    @Override
+    public void didOpen(DocumentUri uri, String content) {
+        Objects.requireNonNull(uri, "uri must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+
+        TextDocumentContentChangeEvent fullText = new TextDocumentContentChangeEvent(content);
+        int version = versionCounters.computeIfAbsent(uri, k -> new AtomicInteger(0)).incrementAndGet();
+        changeBuffer.append(uri, new BufferedChange(fullText, ChangeLayer.EDITOR, new ContentVersion(version)));
+
+        publishDoc(EventKind.WM_DOCUMENT_OPENED, uri);
+    }
+
+    @Override
+    public void didChange(DocumentUri uri, List<TextDocumentContentChangeEvent> changes) {
+        Objects.requireNonNull(uri, "uri must not be null");
+        Objects.requireNonNull(changes, "changes must not be null");
+
+        AtomicInteger counter = versionCounters.computeIfAbsent(uri, k -> new AtomicInteger(0));
+        for (TextDocumentContentChangeEvent change : changes) {
+            int version = counter.incrementAndGet();
+            changeBuffer.append(uri, new BufferedChange(change, ChangeLayer.EDITOR, new ContentVersion(version)));
+        }
+
+        publishDoc(EventKind.WM_DOCUMENT_CHANGED, uri);
+    }
+
+    @Override
+    public void didClose(DocumentUri uri) {
+        Objects.requireNonNull(uri, "uri must not be null");
+
+        changeBuffer.clear(uri);
+        versionCounters.remove(uri);
+
+        publishDoc(EventKind.WM_DOCUMENT_CLOSED, uri);
+    }
+
+    @Override
+    public void didChangeWatchedFiles(List<FileEvent> events) {
+        Objects.requireNonNull(events, "events must not be null");
+
+        for (FileEvent event : events) {
+            try {
+                URI uri = URI.create(event.getUri());
+                DocumentUri docUri = new DocumentUri.FileUri(uri);
+                changeBuffer.routeWatcherEvent(docUri, event);
+                publishDoc(EventKind.WM_FILE_WATCHED_CHANGED, docUri);
+            } catch (Exception ignored) {
+                // Malformed or non-file URI — skip this event
+            }
+        }
+    }
+
     /**
      * Test-only hook: simulates heap pressure by invoking the eviction callback.
      */
@@ -542,6 +610,18 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private void publishWm(EventKind kind, SourceRoot root) {
         eventBus.publish(new DomainEvent(Instant.now(), "workspace-manager", kind,
                 root.path().toString()));
+    }
+
+    /**
+     * Publishes a workspace-manager document event with the document URI as the coalesce scope.
+     * The URI string is used so consumers can reconstruct the path via {@link URI} or {@link Path#of(URI)}.
+     *
+     * @param kind event kind
+     * @param uri  document URI
+     */
+    private void publishDoc(EventKind kind, DocumentUri uri) {
+        eventBus.publish(new DomainEvent(Instant.now(), "workspace-manager", kind,
+                uri.uri().toString()));
     }
 
     /**

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
@@ -84,7 +84,7 @@ public class ProjectServiceTest {
                 publishedEvents::add);
 
         ProjectLoader loader = (root, kind) -> mockBallerinaProject(root, kind);
-        service = new ProjectServiceImpl(registry, uriResolver, eventBus, loader);
+        service = new ProjectServiceImpl(registry, uriResolver, eventBus, loader, new ChangeBuffer());
     }
 
     @AfterMethod


### PR DESCRIPTION
## Purpose

Implement the bridge between LSP document events and the compiler's content
model. `ChangeApplier` drains buffered deltas per-project, clusters them by
module, and applies content via the compiler's `document.modify()` API.
`ProjectService` gains the four document lifecycle methods (`didOpen`,
`didChange`, `didClose`, `didChangeWatchedFiles`) that were previously owned
by `DocumentService`, using `ChangeBuffer` as the intermediary.

## Approach

- `ChangeApplier` iterates `ChangeLayer` values in priority order
  (EDITOR → AI → EXPR), drains pending URIs from `ChangeBuffer`, resolves
  each URI to a compiler `Document` via `UriResolver`, then clusters changes
  by `Module` to pick the optimal modify path: single-document, multi-document
  (same module), or multi-module.
- A `ContentChangeStrategy` interface separates how new content is computed
  from LSP change events. `FullTextChangeStrategy` (default, matches the LS's
  `TextDocumentSyncKind.Full` capability) takes the last event's text.
  `IncrementalChangeStrategy` applies range edits sequentially.
- `ProjectService`/`ProjectServiceImpl` gain the four document lifecycle
  methods. `didOpen` seeds an EDITOR-layer entry (the open/closed marker).
  `didChange` appends per-event. `didClose` clears the buffer. Each publishes
  the corresponding WM-scoped event (WM-E8/E9/E10/E11). `ChangeBuffer` is
  injected into `ProjectServiceImpl` as a constructor parameter.

## What Was Fixed / Changed

- `ChangeApplier` is new — previously no mechanism existed to drain and apply
  buffered changes to the compiler model.
- `ContentChangeStrategy` replaces an earlier application-strategy hierarchy
  that modelled routing (single-doc vs multi-doc) rather than content
  computation; routing is now inlined in `ChangeApplier`.
- `ProjectService` interface extended with `didOpen`, `didChange`, `didClose`,
  `didChangeWatchedFiles`; `ProjectServiceImpl` implements them.
- `WiringConfiguration` updated to pass a `ChangeBuffer` instance to
  `ProjectServiceImpl`.

## Affected Components

- `langserver-core/src/main/java/.../workspace/workspacemanager/`
- `langserver-core/src/main/java/.../workspace/`

## How Has This Been Tested

- `ChangeApplierTest`: unit tests covering single-document, multi-document,
  multi-module clustering; full-text and range-based change strategies; pending
  URI enumeration for default and named modules.
- `ProjectServiceTest`: existing test suite updated to construct
  `ProjectServiceImpl` with a `ChangeBuffer`; document lifecycle integration
  tests are covered by the downstream T-052 task.

## Remarks & Notes

- `applyViaModuleModify` and `applyViaPackageModify` currently fall back to
  per-document `document.modify()` calls; TODO comments mark where batched
  `module.modify()` / `package.modify()` should be used once those APIs are
  public in the compiler.
- `DocumentService` interface and implementation are intentionally left in
  place; dead-code deletion is scoped to T-049.
