### PR TITLE
Route TOML watchers through change buffer

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
@@ -29,6 +29,7 @@ import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
+import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -73,6 +74,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class ProjectServiceImpl implements ProjectService, CacheInvalidationListener {
 
     private static final int DEFAULT_HEAP_MB = 64;
+    private static final String BALLERINA_TOML = "Ballerina.toml";
+    private static final String DEPENDENCIES_TOML = "Dependencies.toml";
+    private static final Set<String> BUFFERED_TOML_FILES = Set.of(BALLERINA_TOML, DEPENDENCIES_TOML, "Cloud.toml");
 
     private final ProjectRegistry registry;
     private final UriResolver uriResolver;
@@ -82,6 +86,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private final ConcurrentHashMap<SourceRoot, Project> ballerinaProjects;
     /** Per-URI monotonically increasing version counter for EDITOR-layer buffered changes. */
     private final ConcurrentHashMap<DocumentUri, AtomicInteger> versionCounters;
+    private final ConcurrentHashMap<Path, AtomicInteger> dependenciesSelfWriteTokens;
 
     /**
      * Constructs a project service with full wiring of dependencies.
@@ -117,6 +122,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         this.changeBuffer = changeBuffer;
         this.ballerinaProjects = new ConcurrentHashMap<>();
         this.versionCounters = new ConcurrentHashMap<>();
+        this.dependenciesSelfWriteTokens = new ConcurrentHashMap<>();
 
         // 1. Wire self as registry listener for eviction and batch events
         registry.addListener(this);
@@ -497,12 +503,43 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
             try {
                 URI uri = URI.create(event.getUri());
                 DocumentUri docUri = new DocumentUri.FileUri(uri);
-                changeBuffer.routeWatcherEvent(docUri, event);
+                Path filePath = Path.of(uri).toAbsolutePath().normalize();
+                if (isBufferedTomlFile(filePath)) {
+                    if (isDependenciesToml(filePath) && consumeDependenciesTomlSelfWrite(filePath)) {
+                        continue;
+                    }
+                    appendWatchedTomlChange(docUri, event.getType());
+                    transitionProjectKindIfNeeded(filePath, event.getType());
+                } else {
+                    changeBuffer.routeWatcherEvent(docUri, event);
+                }
                 publishDoc(EventKind.WM_FILE_WATCHED_CHANGED, docUri);
             } catch (Exception ignored) {
                 // Malformed or non-file URI — skip this event
             }
         }
+    }
+
+    /**
+     * Registers a self-write token for {@code Dependencies.toml} watcher suppression.
+     *
+     * @param dependenciesTomlPath dependencies file path
+     */
+    public void registerDependenciesTomlSelfWrite(Path dependenciesTomlPath) {
+        Objects.requireNonNull(dependenciesTomlPath, "dependenciesTomlPath must not be null");
+
+        Path normalized = dependenciesTomlPath.toAbsolutePath().normalize();
+        if (!isDependenciesToml(normalized)) {
+            return;
+        }
+
+        dependenciesSelfWriteTokens.compute(normalized, (path, counter) -> {
+            if (counter == null) {
+                return new AtomicInteger(1);
+            }
+            counter.incrementAndGet();
+            return counter;
+        });
     }
 
     /**
@@ -599,6 +636,69 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         } catch (IllegalArgumentException ignored) {
             return HeapPressureLevel.WARNING;
         }
+    }
+
+    private void appendWatchedTomlChange(DocumentUri uri, FileChangeType changeType) {
+        AtomicInteger counter = versionCounters.computeIfAbsent(uri, key -> new AtomicInteger(0));
+        int version = counter.incrementAndGet();
+        TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(changeType.name());
+        changeBuffer.append(uri, new BufferedChange(change, ChangeLayer.EDITOR, new ContentVersion(version)));
+    }
+
+    private void transitionProjectKindIfNeeded(Path filePath, FileChangeType changeType) {
+        if (!isBallerinaToml(filePath)
+                || (changeType != FileChangeType.Created && changeType != FileChangeType.Deleted)) {
+            return;
+        }
+
+        Path rootPath = filePath.getParent();
+        if (rootPath == null) {
+            return;
+        }
+
+        ProjectKind targetKind = changeType == FileChangeType.Created ? ProjectKind.BUILD : ProjectKind.SINGLE_FILE;
+        try {
+            transitionKind(new SourceRoot(rootPath.toAbsolutePath().normalize()), targetKind);
+        } catch (IllegalStateException ignored) {
+            // Ignore duplicate or otherwise invalid transitions from watcher replays.
+        }
+    }
+
+    private boolean consumeDependenciesTomlSelfWrite(Path dependenciesTomlPath) {
+        AtomicInteger counter = dependenciesSelfWriteTokens.get(dependenciesTomlPath);
+        if (counter == null) {
+            return false;
+        }
+
+        while (true) {
+            int current = counter.get();
+            if (current <= 0) {
+                dependenciesSelfWriteTokens.remove(dependenciesTomlPath, counter);
+                return false;
+            }
+            if (!counter.compareAndSet(current, current - 1)) {
+                continue;
+            }
+            if (current == 1) {
+                dependenciesSelfWriteTokens.remove(dependenciesTomlPath, counter);
+            }
+            return true;
+        }
+    }
+
+    private boolean isBufferedTomlFile(Path path) {
+        Path fileName = path.getFileName();
+        return fileName != null && BUFFERED_TOML_FILES.contains(fileName.toString());
+    }
+
+    private boolean isBallerinaToml(Path path) {
+        Path fileName = path.getFileName();
+        return fileName != null && BALLERINA_TOML.equals(fileName.toString());
+    }
+
+    private boolean isDependenciesToml(Path path) {
+        Path fileName = path.getFileName();
+        return fileName != null && DEPENDENCIES_TOML.equals(fileName.toString());
     }
 
     /**

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
@@ -27,6 +27,8 @@ import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
 import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -60,6 +62,7 @@ public class ProjectServiceTest {
     private UriResolver uriResolver;
     private EventSyncPubSubHolder eventBus;
     private ProjectServiceImpl service;
+    private ChangeBuffer changeBuffer;
     private Path tempDir;
     private CancelChecker cancelChecker;
     private List<DomainEvent> publishedEvents;
@@ -80,11 +83,13 @@ public class ProjectServiceTest {
         eventBus.subscribe("test-event-logger", SubscriberTier.CRITICAL,
                 Set.of(EventKind.WORKSPACE_PROJECT_REGISTERED, EventKind.WORKSPACE_PROJECT_EVICTED,
                         EventKind.WORKSPACE_PROJECT_HEALTH_STATE_CHANGED, EventKind.WORKSPACE_PROJECT_TIER_CHANGED,
-                        EventKind.WORKSPACE_BATCH_PROJECTS_REGISTERED, EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED),
+                        EventKind.WORKSPACE_BATCH_PROJECTS_REGISTERED, EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED,
+                        EventKind.WM_FILE_WATCHED_CHANGED),
                 publishedEvents::add);
 
         ProjectLoader loader = (root, kind) -> mockBallerinaProject(root, kind);
-        service = new ProjectServiceImpl(registry, uriResolver, eventBus, loader, new ChangeBuffer());
+        changeBuffer = new ChangeBuffer();
+        service = new ProjectServiceImpl(registry, uriResolver, eventBus, loader, changeBuffer);
     }
 
     @AfterMethod
@@ -641,6 +646,93 @@ public class ProjectServiceTest {
                 .filter(e -> e.eventKind() == EventKind.WORKSPACE_PROJECT_HEALTH_STATE_CHANGED)
                 .count();
         Assert.assertEquals(eventCount, 0, "No health state change should occur if not in RECOVERING");
+    }
+
+    // =========================================================================
+    // Watched File Change Tests
+    // =========================================================================
+
+    @Test(groups = "watched-files")
+    public void watchedFiles_cloudTomlBufferedThroughEditorLayer() throws Exception {
+        Path cloudToml = tempDir.resolve("Cloud.toml");
+        Files.writeString(cloudToml, "[cloud]\nname = \"demo\"\n");
+        FileEvent event = new FileEvent(cloudToml.toUri().toString(), FileChangeType.Changed);
+
+        publishedEvents.clear();
+        service.didChangeWatchedFiles(List.of(event));
+        Thread.sleep(100);
+
+        DocumentUri uri = new DocumentUri.FileUri(cloudToml.toUri());
+        List<BufferedChange> bufferedChanges = changeBuffer.drain(uri, ChangeLayer.EDITOR);
+        Assert.assertEquals(bufferedChanges.size(), 1, "Cloud.toml should be buffered in the EDITOR layer");
+        Assert.assertEquals(bufferedChanges.get(0).change().getText(), FileChangeType.Changed.name(),
+                "Watcher change type should be preserved in buffered TOML changes");
+        Assert.assertTrue(publishedEvents.stream().anyMatch(e -> e.eventKind() == EventKind.WM_FILE_WATCHED_CHANGED),
+                "WM_FILE_WATCHED_CHANGED event should be published for buffered TOML changes");
+    }
+
+    @Test(groups = "watched-files")
+    public void watchedFiles_dependenciesTomlSelfWriteSuppressed() throws Exception {
+        Path dependenciesToml = tempDir.resolve("Dependencies.toml");
+        Files.writeString(dependenciesToml, "[[dependency]]\norg = \"wso2\"\n");
+        FileEvent event = new FileEvent(dependenciesToml.toUri().toString(), FileChangeType.Changed);
+
+        publishedEvents.clear();
+        service.registerDependenciesTomlSelfWrite(dependenciesToml);
+        service.didChangeWatchedFiles(List.of(event));
+        Thread.sleep(100);
+
+        DocumentUri uri = new DocumentUri.FileUri(dependenciesToml.toUri());
+        Assert.assertFalse(changeBuffer.hasChanges(uri), "Suppressed Dependencies.toml writes should not be buffered");
+        Assert.assertTrue(publishedEvents.isEmpty(), "Suppressed Dependencies.toml writes should produce no events");
+    }
+
+    @Test(groups = "watched-files")
+    public void watchedFiles_ballerinaTomlCreationTransitionsProjectKind() throws Exception {
+        Path singleFileDir = Files.createTempDirectory("test-single-file-watched-create");
+        service.loadOrCreate(singleFileDir, cancelChecker);
+
+        Path ballerinaToml = singleFileDir.resolve("Ballerina.toml");
+        Files.writeString(ballerinaToml, "[package]\norg = \"test\"\nname = \"demo\"\n");
+        FileEvent event = new FileEvent(ballerinaToml.toUri().toString(), FileChangeType.Created);
+
+        publishedEvents.clear();
+        service.didChangeWatchedFiles(List.of(event));
+        Thread.sleep(200);
+
+        SourceRoot root = new SourceRoot(singleFileDir.toAbsolutePath().normalize());
+        Assert.assertEquals(registry.get(root).orElseThrow().kind(), ProjectKind.BUILD,
+                "Ballerina.toml creation should transition the project to BUILD");
+        Assert.assertTrue(publishedEvents.stream()
+                        .anyMatch(e -> e.eventKind() == EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED),
+                "Ballerina.toml creation should publish a kind transition event");
+        DocumentUri uri = new DocumentUri.FileUri(ballerinaToml.toUri());
+        Assert.assertEquals(changeBuffer.drain(uri, ChangeLayer.EDITOR).size(), 1,
+                "Ballerina.toml creation should still buffer the TOML change");
+    }
+
+    @Test(groups = "watched-files")
+    public void watchedFiles_ballerinaTomlDeletionTransitionsProjectKind() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+
+        Path ballerinaToml = projectPath.resolve("Ballerina.toml");
+        Files.deleteIfExists(ballerinaToml);
+        FileEvent event = new FileEvent(ballerinaToml.toUri().toString(), FileChangeType.Deleted);
+
+        publishedEvents.clear();
+        service.didChangeWatchedFiles(List.of(event));
+        Thread.sleep(200);
+
+        SourceRoot root = new SourceRoot(projectPath);
+        Assert.assertEquals(registry.get(root).orElseThrow().kind(), ProjectKind.SINGLE_FILE,
+                "Ballerina.toml deletion should transition the project to SINGLE_FILE");
+        Assert.assertTrue(publishedEvents.stream()
+                        .anyMatch(e -> e.eventKind() == EventKind.WORKSPACE_PROJECT_KIND_TRANSITIONED),
+                "Ballerina.toml deletion should publish a kind transition event");
+        DocumentUri uri = new DocumentUri.FileUri(ballerinaToml.toUri());
+        Assert.assertEquals(changeBuffer.drain(uri, ChangeLayer.EDITOR).size(), 1,
+                "Ballerina.toml deletion should still buffer the TOML change");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Purpose

Align watched TOML handling with the buffered document-change model so
configuration file updates follow the same workspace path as editor
edits, while preserving project kind transitions for Ballerina.toml and
self-write suppression for Dependencies.toml.

## Approach

- Route watched TOML changes through `ChangeBuffer` in `ProjectServiceImpl`.
- Keep Ballerina.toml create/delete events responsible for project kind
  transitions.
- Retain Dependencies.toml self-write suppression in the workspace
  manager.
- Add workspace-manager tests for buffered TOML events, suppressed
  self-writes, and Ballerina.toml kind transitions.

## What Was Fixed / Changed

- Watched Cloud.toml, Dependencies.toml, and Ballerina.toml updates now
  enter the EDITOR buffer path instead of a separate watcher route.
- Ballerina.toml creation and deletion still trigger BUILD/SINGLE_FILE
  transitions.
- Dependencies.toml self-generated writes are ignored before they can
  re-enter the watcher flow.
- Tests now cover the TOML buffering and project-kind behavior.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager`

## How Has This Been Tested

- `./gradlew :langserver-core:compileTestJava`
- `./gradlew :langserver-core:test --tests "org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceTest"`
- `./gradlew :langserver-core:test --tests "org.ballerinalang.langserver.workspace.WiringConfigurationTest"`
- `./gradlew :langserver-core:test`

## Remarks & Notes

- The broader `documentstore` TOML enum cleanup was intentionally left
  out of scope for this task.
- Full `langserver-core` test execution still reports unrelated
  definition/expression test failures.
