### PR TITLE
Complete v2.0 workspace manager migration

### DIFF
--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/ThreadSafetyTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/ThreadSafetyTest.java
@@ -17,125 +17,380 @@
  */
 package org.ballerinalang.langserver.workspace.test.acceptance;
 
-import org.ballerinalang.langserver.workspace.workspacemanager.HeapEstimate;
-import org.ballerinalang.langserver.workspace.workspacemanager.Project;
-import org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind;
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.InProgressSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.ballerinalang.langserver.workspace.documentstore.DocumentUri;
+import org.ballerinalang.langserver.workspace.workspacemanager.BufferedChange;
+import org.ballerinalang.langserver.workspace.workspacemanager.ChangeBuffer;
+import org.ballerinalang.langserver.workspace.workspacemanager.ChangeLayer;
+import org.ballerinalang.langserver.workspace.workspacemanager.ResolvedEntry;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
+import org.ballerinalang.langserver.workspace.workspacemanager.UriResolver;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
 
 /**
- * Acceptance tests for thread safety and concurrency constraints.
+ * Acceptance tests for thread safety and concurrency constraints in the v2.0 concurrency model.
+ * Covers UriResolver lock-free reads (ADR-048), ChangeBuffer concurrent append/drain (ADR-047),
+ * and DualSnapshotStore atomic publish (ADR-042).
  *
  * @since 1.7.0
  */
 public class ThreadSafetyTest {
 
+    // -------------------------------------------------------------------------
+    // UriResolver (ADR-048) — lock-free reads via AtomicReference<TrieNode>
+    // -------------------------------------------------------------------------
+
+    /**
+     * 100 reader threads resolve concurrently while 1 writer registers a new entry.
+     * All readers must complete without blocking — lock-free guarantee of ADR-048.
+     */
     @Test
-    public void testGlobalRegistriesUseConcurrentHashMap() throws Exception {
-        // RED: this test should fail — verify global registries use ConcurrentHashMap
-        checkFieldType("org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry", "cache", com.google.common.cache.Cache.class);
-        // ProjectRegistry uses Guava Cache, but its internal map is ConcurrentHashMap.
-        // Let's check other registries.
-        checkFieldType("org.ballerinalang.langserver.workspace.execution.ProcessRegistry", "processes", ConcurrentHashMap.class);
-    }
+    public void testUriResolverLockFreeReads() throws Exception {
+        UriResolver resolver = new UriResolver();
+        DocumentUri uri = new DocumentUri.FileUri(URI.create("file:///tmp/proj/main.bal"));
+        ResolvedEntry entry = new ResolvedEntry.DocumentEntry(mock(io.ballerina.projects.Document.class));
+        resolver.register(uri, entry);
 
-    @Test
-    public void testBuildOptionsGuardedByAtomicReference() throws Exception {
-        // RED: this test should fail — verify buildOptions uses AtomicReference
-        checkFieldType("org.ballerinalang.langserver.workspace.workspacemanager.LockingModeController", "state", AtomicReference.class);
-    }
+        int readerCount = 100;
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(readerCount);
+        AtomicInteger successCount = new AtomicInteger(0);
 
-    @Test
-    public void testProjectLockIsReadWrite() throws Exception {
-        // RED: this test should fail — verify ProjectLock uses ReentrantReadWriteLock
-        checkFieldType("org.ballerinalang.langserver.workspace.workspacemanager.ProjectLock", "lock", ReentrantReadWriteLock.class);
-    }
-
-    @Test
-    public void testNoRawCollectionsInMultiThreadedFields() throws Exception {
-        // RED: this test should fail — verify no HashSet/HashMap in multi-threaded contexts
-        String[] classesToCheck = {
-                "org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry",
-                "org.ballerinalang.langserver.workspace.execution.ProcessRegistry"
-        };
-
-        for (String className : classesToCheck) {
-            Class<?> clazz = Class.forName(className);
-            for (Field field : clazz.getDeclaredFields()) {
-                if (!Modifier.isStatic(field.getModifiers())) {
-                    String typeName = field.getType().getName();
-                    Assert.assertFalse(typeName.equals("java.util.HashMap") || 
-                                     typeName.equals("java.util.HashSet") || 
-                                     typeName.equals("java.util.LinkedHashMap"),
-                            "Field " + field.getName() + " in " + className + " uses non-thread-safe collection: " + typeName);
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testConcurrentReadsDoNotBlockEachOther() throws Exception {
-        Project project = new Project(new SourceRoot(Paths.get("/tmp/test")), ProjectKind.BUILD, HeapEstimate.ofMb(10));
-        Lock readLock = project.projectLock().readLock();
-
-        int threadCount = 10;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
-
-        for (int i = 0; i < threadCount; i++) {
-            futures.add(CompletableFuture.runAsync(() -> {
-                boolean acquired = readLock.tryLock();
-                Assert.assertTrue(acquired, "Read lock should be acquired concurrently");
+        ExecutorService readers = Executors.newFixedThreadPool(readerCount);
+        for (int i = 0; i < readerCount; i++) {
+            readers.submit(() -> {
                 try {
-                    Thread.sleep(100);
+                    startGate.await();
+                    Optional<ResolvedEntry> result = resolver.resolve(uri);
+                    if (result.isPresent()) {
+                        successCount.incrementAndGet();
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 } finally {
-                    readLock.unlock();
+                    done.countDown();
                 }
-            }, executor));
-        }
-
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-        executor.shutdown();
-    }
-
-    @Test
-    public void testWriteLockBlocksReaders() throws Exception {
-        Project project = new Project(new SourceRoot(Paths.get("/tmp/test")), ProjectKind.BUILD, HeapEstimate.ofMb(10));
-        Lock readLock = project.projectLock().readLock();
-        Lock writeLock = project.projectLock().writeLock();
-
-        writeLock.lock();
-        try {
-            CompletableFuture<Boolean> readerFuture = CompletableFuture.supplyAsync(() -> {
-                return readLock.tryLock();
             });
-            Assert.assertFalse(readerFuture.get(), "Reader should be blocked by writer");
-        } finally {
-            writeLock.unlock();
         }
+
+        // Writer registers another entry concurrently while readers are active
+        DocumentUri uri2 = new DocumentUri.FileUri(URI.create("file:///tmp/proj/util.bal"));
+        ResolvedEntry entry2 = new ResolvedEntry.DocumentEntry(mock(io.ballerina.projects.Document.class));
+        startGate.countDown();
+        resolver.register(uri2, entry2);
+        done.await();
+        readers.shutdown();
+
+        Assert.assertEquals(successCount.get(), readerCount,
+                "All 100 readers must resolve the registered entry without blocking");
     }
 
-    private void checkFieldType(String className, String fieldName, Class<?> expectedType) throws Exception {
-        Class<?> clazz = Class.forName(className);
-        Field field = clazz.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        Assert.assertTrue(expectedType.isAssignableFrom(field.getType()),
-                "Field " + fieldName + " in " + className + " should be " + expectedType.getSimpleName() + " but was " + field.getType().getSimpleName());
+    /**
+     * A reader that resolves before a write sees consistent stale data —
+     * the old entry remains valid and present in the snapshot it observed.
+     */
+    @Test
+    public void testUriResolverSnapshotConsistency() {
+        UriResolver resolver = new UriResolver();
+        DocumentUri uriA = new DocumentUri.FileUri(URI.create("file:///tmp/proj/a.bal"));
+        DocumentUri uriB = new DocumentUri.FileUri(URI.create("file:///tmp/proj/b.bal"));
+        DocumentUri uriC = new DocumentUri.FileUri(URI.create("file:///tmp/proj/c.bal"));
+        ResolvedEntry entryA = new ResolvedEntry.DocumentEntry(mock(io.ballerina.projects.Document.class));
+        ResolvedEntry entryB = new ResolvedEntry.DocumentEntry(mock(io.ballerina.projects.Document.class));
+
+        resolver.register(uriA, entryA);
+
+        // Resolve before registering B — must see A, not be affected by the subsequent write
+        Optional<ResolvedEntry> beforeWrite = resolver.resolve(uriA);
+        resolver.register(uriB, entryB);
+
+        Assert.assertTrue(beforeWrite.isPresent(), "Entry A must be visible before write");
+        Assert.assertSame(beforeWrite.get(), entryA, "Stale read must return original entry A");
+        Assert.assertTrue(resolver.resolve(uriB).isPresent(), "Entry B must be visible after registration");
+        Assert.assertFalse(resolver.resolve(uriC).isPresent(), "Unregistered URI must resolve to empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // ChangeBuffer (ADR-047) — ConcurrentHashMap-based concurrent append/drain
+    // -------------------------------------------------------------------------
+
+    /**
+     * 10 threads each append 100 changes to the same URI simultaneously.
+     * Draining afterwards must yield exactly 1000 changes — no data loss.
+     */
+    @Test
+    public void testChangeBufferConcurrentAppend() throws Exception {
+        ChangeBuffer buffer = new ChangeBuffer();
+        DocumentUri uri = new DocumentUri.FileUri(URI.create("file:///tmp/proj/main.bal"));
+        ContentVersion version = new ContentVersion(1);
+
+        int threadCount = 10;
+        int changesPerThread = 100;
+        CyclicBarrier startBarrier = new CyclicBarrier(threadCount);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        ExecutorService writers = Executors.newFixedThreadPool(threadCount);
+        for (int t = 0; t < threadCount; t++) {
+            writers.submit(() -> {
+                try {
+                    startBarrier.await();
+                    for (int i = 0; i < changesPerThread; i++) {
+                        TextDocumentContentChangeEvent event = new TextDocumentContentChangeEvent();
+                        event.setText("change-" + i);
+                        buffer.append(uri, new BufferedChange(event, ChangeLayer.EDITOR, version));
+                    }
+                } catch (Exception e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        done.await();
+        writers.shutdown();
+
+        List<BufferedChange> drained = buffer.drain(uri, ChangeLayer.EDITOR);
+        Assert.assertEquals(drained.size(), threadCount * changesPerThread,
+                "All " + (threadCount * changesPerThread) + " changes must be present — no data loss from concurrent append");
+    }
+
+    /**
+     * Drain and append run concurrently on the same URI.
+     * Total drained + remaining in buffer must equal total appended — no data loss or duplication.
+     */
+    @Test
+    public void testChangeBufferConcurrentDrainAndAppend() throws Exception {
+        ChangeBuffer buffer = new ChangeBuffer();
+        DocumentUri uri = new DocumentUri.FileUri(URI.create("file:///tmp/proj/main.bal"));
+        ContentVersion version = new ContentVersion(1);
+
+        int appendThreads = 5;
+        int changesPerThread = 50;
+        AtomicInteger totalAppended = new AtomicInteger(0);
+        AtomicInteger totalDrained = new AtomicInteger(0);
+        CyclicBarrier startBarrier = new CyclicBarrier(appendThreads + 1);
+        CountDownLatch done = new CountDownLatch(appendThreads + 1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(appendThreads + 1);
+
+        for (int t = 0; t < appendThreads; t++) {
+            executor.submit(() -> {
+                try {
+                    startBarrier.await();
+                    for (int i = 0; i < changesPerThread; i++) {
+                        TextDocumentContentChangeEvent event = new TextDocumentContentChangeEvent();
+                        event.setText("c");
+                        buffer.append(uri, new BufferedChange(event, ChangeLayer.EDITOR, version));
+                        totalAppended.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        executor.submit(() -> {
+            try {
+                startBarrier.await();
+                for (int round = 0; round < 10; round++) {
+                    List<BufferedChange> drained = buffer.drain(uri, ChangeLayer.EDITOR);
+                    totalDrained.addAndGet(drained.size());
+                    Thread.yield();
+                }
+            } catch (Exception e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                done.countDown();
+            }
+        });
+
+        done.await();
+        executor.shutdown();
+
+        List<BufferedChange> remaining = buffer.drain(uri, ChangeLayer.EDITOR);
+        int finalTotal = totalDrained.get() + remaining.size();
+
+        Assert.assertEquals(finalTotal, totalAppended.get(),
+                "drained + remaining must equal total appended — no data loss or duplication");
+    }
+
+    // -------------------------------------------------------------------------
+    // DualSnapshotStore (ADR-042) — atomic snapshot publication
+    // -------------------------------------------------------------------------
+
+    /**
+     * getStable() returns null before any publishStable() call.
+     */
+    @Test
+    public void testDualSnapshotStoreNullBeforeFirstPublish() {
+        DualSnapshotStore store = new DualSnapshotStore();
+        SourceRoot sourceRoot = new SourceRoot(Paths.get("/tmp/proj"));
+
+        Assert.assertNull(store.getStable(sourceRoot),
+                "getStable() must return null before any publishStable() call");
+    }
+
+    /**
+     * 50 concurrent readers call getStable() while a writer calls publishStable().
+     * Every reader must see either the old or the new snapshot — never a partial state.
+     */
+    @Test
+    public void testDualSnapshotStoreAtomicPublish() throws Exception {
+        DualSnapshotStore store = new DualSnapshotStore();
+        SourceRoot sourceRoot = new SourceRoot(Paths.get("/tmp/proj"));
+
+        StableSnapshot oldSnapshot = stubSnapshot(new ContentVersion(1));
+        StableSnapshot newSnapshot = stubSnapshot(new ContentVersion(2));
+
+        store.publishStable(sourceRoot, oldSnapshot);
+
+        int readerCount = 50;
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(readerCount + 1);
+        Set<StableSnapshot> seen = ConcurrentHashMap.newKeySet();
+
+        ExecutorService executor = Executors.newFixedThreadPool(readerCount + 1);
+
+        for (int i = 0; i < readerCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startGate.await();
+                    StableSnapshot result = store.getStable(sourceRoot);
+                    if (result != null) {
+                        seen.add(result);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        executor.submit(() -> {
+            try {
+                startGate.await();
+                store.publishStable(sourceRoot, newSnapshot);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                done.countDown();
+            }
+        });
+
+        startGate.countDown();
+        done.await();
+        executor.shutdown();
+
+        for (StableSnapshot snap : seen) {
+            Assert.assertTrue(snap == oldSnapshot || snap == newSnapshot,
+                    "Reader observed a snapshot that is neither old nor new — atomic publish violated");
+        }
+        Assert.assertSame(store.getStable(sourceRoot), newSnapshot,
+                "After publishStable(), getStable() must return the new snapshot");
+    }
+
+    /**
+     * 10 threads call startCompilation() concurrently on the same SourceRoot.
+     * All calls must return a non-null InProgressSnapshot, and the store's
+     * getInProgress() result must be one of the returned snapshots.
+     */
+    @Test
+    public void testDualSnapshotStoreStartCompilationIsAtomic() throws Exception {
+        DualSnapshotStore store = new DualSnapshotStore();
+        SourceRoot sourceRoot = new SourceRoot(Paths.get("/tmp/proj"));
+
+        int threadCount = 10;
+        CyclicBarrier startBarrier = new CyclicBarrier(threadCount);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        List<InProgressSnapshot> created = new ArrayList<>();
+        Object listLock = new Object();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startBarrier.await();
+                    InProgressSnapshot snapshot = store.startCompilation(sourceRoot);
+                    synchronized (listLock) {
+                        created.add(snapshot);
+                    }
+                } catch (Exception e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        done.await();
+        executor.shutdown();
+
+        Assert.assertEquals(created.size(), threadCount,
+                "All startCompilation() calls must return a non-null snapshot");
+        for (InProgressSnapshot snap : created) {
+            Assert.assertNotNull(snap, "startCompilation() must never return null");
+        }
+
+        InProgressSnapshot current = store.getInProgress(sourceRoot);
+        Assert.assertNotNull(current, "After concurrent startCompilation(), one InProgressSnapshot must remain active");
+        Assert.assertTrue(created.contains(current),
+                "Active InProgressSnapshot must be one of the snapshots returned by startCompilation()");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static StableSnapshot stubSnapshot(ContentVersion version) {
+        return new StableSnapshot() {
+            @Override
+            public SyntaxTree syntaxTree(DocumentId docId) {
+                return null;
+            }
+
+            @Override
+            public ContentVersion contentVersion() {
+                return version;
+            }
+
+            @Override
+            public SemanticModel semanticModel(ModuleId moduleId) {
+                return null;
+            }
+
+            @Override
+            public PackageCompilation compilation() {
+                return null;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Purpose

Complete the v2.0 workspace manager migration: remove the proxy
indirection layer, rebuild the component graph wiring, and bring all
acceptance tests in line with the new concurrency model.

## Approach

- Remove direct usage of `BallerinaWorkspaceManagerProxy` from the
  language server bootstrap and service classes; wire `workspaceManager`
  directly. The proxy types are deprecated but not yet deleted to allow
  external call-site migration.
- Rewrite `WiringConfiguration` to construct the v2.0 component graph
  (ProjectService, CompilationService, DualSnapshotStore, ChangeBuffer,
  UriResolver) without VFS or PathToRootCache.
- Strip `DocumentService` from `WorkspaceManagerFacadeImpl`; delegate
  document open/change/close lifecycle to `ProjectServiceImpl`.
- Route TOML file-watcher events through `ChangeBuffer` alongside source
  changes so the compilation pipeline receives them uniformly.
- Fix `CompilationPipeline` to retain the replacement `InProgressSnapshot`
  when `startCompilation` is called while one is already running.
- Migrate acceptance tests: remove suites that reference deleted constructs
  and add new ones targeting `UriResolver`, `ChangeBuffer`,
  `DualSnapshotStore`, `ProjectService` document lifecycle, locking mode,
  and recovery ladder.

## What Was Fixed / Changed

- `BallerinaLanguageServer`, `BallerinaTextDocumentService`,
  `BallerinaWorkspaceService` — proxy references replaced with direct
  workspace manager wiring.
- `WiringConfiguration` — rebuilt for the v2.0 component graph; VFS,
  PathToRootCache, and old SnapshotStore wiring removed.
- `WorkspaceManagerFacadeImpl` — `DocumentService` dependency removed;
  lifecycle operations delegated to `ProjectService`.
- `CompilationPipeline` — in-progress snapshot preserved correctly on
  concurrent re-compilation.
- `ProjectService` / `ProjectServiceImpl` — document lifecycle methods
  (`didOpen`, `didChange`, `didClose`) added.
- `ThreadSafetyTest` — replaced tests for deleted constructs with seven
  concurrency tests covering lock-free UriResolver reads (100 threads),
  ChangeBuffer concurrent append/drain (10 × 100 changes, no data loss),
  and DualSnapshotStore atomic publish.
- `ChangeBufferAcceptanceTest`, `LockingModeTest`,
  `RecoveryLadderAcceptanceTest`, `ProjectServiceDocumentTest` — new
  acceptance test suites added.

## Affected Components

- `langserver-core/src/main/java/.../workspace/` — wiring, facade, service
  implementations, compilation pipeline
- `langserver-core/src/main/java/...` (top-level) — language server
  bootstrap and LSP service classes
- `langserver-core/src/test/java/.../workspace/` — acceptance and unit
  tests for all workspace sub-systems

## How Has This Been Tested

- New acceptance tests exercise the public API of each component in
  isolation: `ChangeBufferAcceptanceTest` (append/drain/layer semantics),
  `LockingModeTest` (SOFT/MEDIUM/HARD/LOCKED transitions),
  `ThreadSafetyTest` (lock-free reads, no data loss under contention),
  `ProjectServiceDocumentTest` (open/change/close lifecycle).
- `WiringConfigurationTest` and `WorkspaceManagerFacadeImplTest` updated
  to cover the new component graph.
- All tests use `CountDownLatch`/`CyclicBarrier` for deterministic
  concurrency verification — no `Thread.sleep`.

## Remarks & Notes

- `BallerinaWorkspaceManagerProxy` and `BallerinaWorkspaceManagerProxyImpl`
  are deprecated (`@Deprecated(forRemoval = true)`) and will be deleted
  once external consumers have migrated.
