### PR TITLE
Update cross-context boundary coverage

### DIFF
--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImpl.java
@@ -26,6 +26,7 @@ import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
+import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
 import org.ballerinalang.langserver.workspace.workspacemanager.LockingMode;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -45,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -65,10 +67,13 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
     private final EventSyncPubSubHolder eventBus;
     private final CompilationPipeline.CompilationAction baseAction;
     private final long retryDelayMs;
+    private final long heapPressureThrottleMs;
     private final ScheduledExecutorService retryScheduler;
     private final Map<SourceRoot, CompilationPipeline> pipelines;
     private final Map<SourceRoot, CircuitBreakerAction> circuitActions;
+    private final Map<SourceRoot, ScheduledFuture<?>> throttledRequests;
     private final AtomicInteger versionCounter;
+    private final AtomicLong throttledUntilNanos;
     private final AtomicBoolean closed;
 
     /**
@@ -80,7 +85,7 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
      */
     public CompilationServiceImpl(DualSnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
                                   CompilationPipeline.CompilationAction baseAction) {
-        this(snapshotStore, eventBus, baseAction, 500L);
+        this(snapshotStore, eventBus, baseAction, 500L, 250L);
     }
 
     /**
@@ -93,13 +98,31 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
      */
     public CompilationServiceImpl(DualSnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
                                   CompilationPipeline.CompilationAction baseAction, long retryDelayMs) {
+        this(snapshotStore, eventBus, baseAction, retryDelayMs, 250L);
+    }
+
+    /**
+     * Creates a compilation service with configurable retry delay and RM-E1 throttle window.
+     *
+     * @param snapshotStore snapshot store for publishing compiled snapshots
+     * @param eventBus event bus for publishing/subscribing to domain events
+     * @param baseAction the underlying compilation action to wrap with circuit breaker
+     * @param retryDelayMs delay in milliseconds before retrying a transient failure
+     * @param heapPressureThrottleMs delay in milliseconds to defer document-triggered recompilation after RM-E1
+     */
+    public CompilationServiceImpl(DualSnapshotStore snapshotStore, EventSyncPubSubHolder eventBus,
+                                  CompilationPipeline.CompilationAction baseAction, long retryDelayMs,
+                                  long heapPressureThrottleMs) {
         this.snapshotStore = Objects.requireNonNull(snapshotStore, "snapshotStore must not be null");
         this.eventBus = Objects.requireNonNull(eventBus, "eventBus must not be null");
         this.baseAction = Objects.requireNonNull(baseAction, "baseAction must not be null");
         this.retryDelayMs = retryDelayMs;
+        this.heapPressureThrottleMs = heapPressureThrottleMs;
         this.pipelines = new ConcurrentHashMap<>();
         this.circuitActions = new ConcurrentHashMap<>();
+        this.throttledRequests = new ConcurrentHashMap<>();
         this.versionCounter = new AtomicInteger(0);
+        this.throttledUntilNanos = new AtomicLong(0L);
         this.closed = new AtomicBoolean(false);
         this.retryScheduler = Executors.newScheduledThreadPool(1, r -> {
             Thread t = new Thread(r, "ce-retry-scheduler");
@@ -164,8 +187,10 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
         }
         pipelines.values().forEach(CompilationPipeline::close);
         pipelines.keySet().forEach(snapshotStore::remove);
+        throttledRequests.values().forEach(future -> future.cancel(false));
         pipelines.clear();
         circuitActions.clear();
+        throttledRequests.clear();
         retryScheduler.shutdownNow();
     }
 
@@ -183,6 +208,9 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
                        EventKind.WM_DOCUMENT_CHANGED,
                        EventKind.WM_FILE_WATCHED_CHANGED),
                 this::handleDocumentEvent);
+
+        eventBus.subscribe("ce-heap-pressure-events", SubscriberTier.CRITICAL,
+                Set.of(EventKind.RM_E1_HEAP_PRESSURE_DETECTED), this::handleHeapPressureEvent);
     }
 
     private void handleWorkspaceEvent(DomainEvent event) {
@@ -222,23 +250,76 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
 
     private void handleDocumentChanged(DomainEvent event) {
         SourceRoot sourceRoot = reconstructSourceRoot(event);
-        CompilationPipeline pipeline = pipelines.get(sourceRoot);
-        if (pipeline != null) {
-            ContentVersion nextVersion = new ContentVersion(versionCounter.getAndIncrement());
-            pipeline.requestCompilation(nextVersion);
-        }
+        requestCompilationWithThrottle(sourceRoot);
     }
 
     private void handleFileWatchedChanged(DomainEvent event) {
         SourceRoot sourceRoot = reconstructSourceRoot(event);
         if (isDependencyGraphChange(event.coalesceScope())) {
-            CompilationPipeline pipeline = pipelines.get(sourceRoot);
-            if (pipeline != null) {
-                ContentVersion nextVersion = new ContentVersion(versionCounter.getAndIncrement());
-                pipeline.requestCompilation(nextVersion);
-            }
+            requestCompilationWithThrottle(sourceRoot);
         }
         // "CONFIGURATION" scope is ignored
+    }
+
+    private void handleHeapPressureEvent(DomainEvent event) {
+        if (heapPressureThrottleMs <= 0) {
+            return;
+        }
+        HeapPressureLevel level = parseHeapPressureLevel(event.coalesceScope());
+        switch (level) {
+            case WARNING, CRITICAL, EMERGENCY ->
+                    throttledUntilNanos.set(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(heapPressureThrottleMs));
+            case NORMAL -> throttledUntilNanos.set(0L);
+        }
+    }
+
+    private void requestCompilationWithThrottle(SourceRoot sourceRoot) {
+        CompilationPipeline pipeline = pipelines.get(sourceRoot);
+        if (pipeline == null) {
+            return;
+        }
+
+        long delayNanos = throttledUntilNanos.get() - System.nanoTime();
+        if (delayNanos <= 0) {
+            cancelThrottledRequest(sourceRoot);
+            requestCompilation(pipeline);
+            return;
+        }
+
+        ScheduledFuture<?> existing = throttledRequests.remove(sourceRoot);
+        if (existing != null) {
+            existing.cancel(false);
+        }
+
+        ScheduledFuture<?> scheduled = retryScheduler.schedule(() -> {
+            throttledRequests.remove(sourceRoot);
+            CompilationPipeline activePipeline = pipelines.get(sourceRoot);
+            if (activePipeline != null && !closed.get()) {
+                requestCompilation(activePipeline);
+            }
+        }, TimeUnit.NANOSECONDS.toMillis(delayNanos), TimeUnit.MILLISECONDS);
+        throttledRequests.put(sourceRoot, scheduled);
+    }
+
+    private void requestCompilation(CompilationPipeline pipeline) {
+        ContentVersion nextVersion = new ContentVersion(versionCounter.getAndIncrement());
+        pipeline.requestCompilation(nextVersion);
+    }
+
+    private void cancelThrottledRequest(SourceRoot sourceRoot) {
+        ScheduledFuture<?> pendingRequest = throttledRequests.remove(sourceRoot);
+        if (pendingRequest != null) {
+            pendingRequest.cancel(false);
+        }
+    }
+
+    private HeapPressureLevel parseHeapPressureLevel(String scope) {
+        try {
+            return HeapPressureLevel.valueOf(scope);
+        } catch (IllegalArgumentException ex) {
+            LOG.log(Level.FINE, "Unknown heap pressure level: {0}", scope);
+            return HeapPressureLevel.NORMAL;
+        }
     }
 
     private void createPipelineIfAbsent(SourceRoot sourceRoot) {
@@ -263,6 +344,10 @@ public class CompilationServiceImpl implements CompilationService, AutoCloseable
     private void evictPipeline(SourceRoot sourceRoot) {
         CompilationPipeline pipeline = pipelines.remove(sourceRoot);
         circuitActions.remove(sourceRoot);
+        ScheduledFuture<?> pendingRequest = throttledRequests.remove(sourceRoot);
+        if (pendingRequest != null) {
+            pendingRequest.cancel(false);
+        }
         if (pipeline != null) {
             pipeline.close();
             snapshotStore.remove(sourceRoot);

--- a/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
+++ b/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceImpl.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     /** Per-URI monotonically increasing version counter for EDITOR-layer buffered changes. */
     private final ConcurrentHashMap<DocumentUri, AtomicInteger> versionCounters;
     private final ConcurrentHashMap<Path, AtomicInteger> dependenciesSelfWriteTokens;
+    private final ConcurrentHashMap<SourceRoot, Set<EventKind>> observedCompilerSignals;
 
     /**
      * Constructs a project service with full wiring of dependencies.
@@ -123,6 +125,7 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         this.ballerinaProjects = new ConcurrentHashMap<>();
         this.versionCounters = new ConcurrentHashMap<>();
         this.dependenciesSelfWriteTokens = new ConcurrentHashMap<>();
+        this.observedCompilerSignals = new ConcurrentHashMap<>();
 
         // 1. Wire self as registry listener for eviction and batch events
         registry.addListener(this);
@@ -136,6 +139,12 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
                 Set.of(EventKind.COMPILER_COMPILATION_FAILED), this::onCompilationFailed);
         eventBus.subscribe("wm-diagnostics-ready", SubscriberTier.CRITICAL,
                 Set.of(EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY), this::onDiagnosticsReady);
+        eventBus.subscribe("wm-resolution-diagnostics-ready", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY), this::onResolutionDiagnosticsReady);
+        eventBus.subscribe("wm-resolution-recovered", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_RESOLUTION_RECOVERED), this::onResolutionRecovered);
+        eventBus.subscribe("wm-resolution-exhausted", SubscriberTier.CRITICAL,
+                Set.of(EventKind.CE_RESOLUTION_EXHAUSTED), this::onResolutionExhausted);
         eventBus.subscribe("rm-heap-pressure", SubscriberTier.CRITICAL,
                 Set.of(EventKind.RM_E1_HEAP_PRESSURE_DETECTED), this::onHeapPressureDetected);
 
@@ -338,8 +347,9 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     }
 
     private void onDiagnosticsReady(DomainEvent event) {
-        Path root = parsePath(event.coalesceScope());
-        registry.get(new SourceRoot(root)).ifPresent(project -> {
+        SourceRoot root = new SourceRoot(parsePath(event.coalesceScope()));
+        recordCompilerSignal(root, event.eventKind());
+        registry.get(root).ifPresent(project -> {
             if (project.healthState() == ProjectHealthState.RECOVERING) {
                 try {
                     project.transitionTo(ProjectHealthState.HEALTHY);
@@ -351,12 +361,34 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
         });
     }
 
+    private void onResolutionDiagnosticsReady(DomainEvent event) {
+        recordCompilerSignal(new SourceRoot(parsePath(event.coalesceScope())), event.eventKind());
+    }
+
+    private void onResolutionRecovered(DomainEvent event) {
+        SourceRoot root = new SourceRoot(parsePath(event.coalesceScope()));
+        recordCompilerSignal(root, event.eventKind());
+        registry.get(root).ifPresent(project -> transitionProject(project, ProjectHealthState.RECOVERING));
+    }
+
+    private void onResolutionExhausted(DomainEvent event) {
+        SourceRoot root = new SourceRoot(parsePath(event.coalesceScope()));
+        recordCompilerSignal(root, event.eventKind());
+        registry.get(root).ifPresent(project -> transitionProject(project, ProjectHealthState.CIRCUIT_OPEN));
+    }
+
     private void onHeapPressureDetected(DomainEvent event) {
         HeapPressureLevel level = parseHeapPressureLevel(event.coalesceScope());
         switch (level) {
             case WARNING, CRITICAL, EMERGENCY -> registry.evictBackgroundProjects();
             case NORMAL -> { }
         }
+    }
+
+    boolean hasObservedCompilerSignal(SourceRoot root, EventKind signal) {
+        Objects.requireNonNull(root, "root must not be null");
+        Objects.requireNonNull(signal, "signal must not be null");
+        return observedCompilerSignals.getOrDefault(root, Collections.emptySet()).contains(signal);
     }
 
     // =========================================================================
@@ -710,6 +742,25 @@ public final class ProjectServiceImpl implements ProjectService, CacheInvalidati
     private void publishWm(EventKind kind, SourceRoot root) {
         eventBus.publish(new DomainEvent(Instant.now(), "workspace-manager", kind,
                 root.path().toString()));
+    }
+
+    private void recordCompilerSignal(SourceRoot root, EventKind signal) {
+        if (registry.get(root).isEmpty()) {
+            return;
+        }
+        observedCompilerSignals.computeIfAbsent(root, ignored -> ConcurrentHashMap.newKeySet()).add(signal);
+    }
+
+    private void transitionProject(org.ballerinalang.langserver.workspace.workspacemanager.Project project,
+                                   ProjectHealthState target) {
+        try {
+            if (project.healthState() != target) {
+                project.transitionTo(target);
+                publishWm(EventKind.WORKSPACE_PROJECT_HEALTH_STATE_CHANGED, project.sourceRoot());
+            }
+        } catch (IllegalStateException ignored) {
+            // Ignore compiler lifecycle signals that do not map to a valid arc for the current state.
+        }
     }
 
     /**

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/compilerengine/CompilationServiceImplTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
 import org.ballerinalang.langserver.workspace.eventbus.EventKind;
 import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
 import org.ballerinalang.langserver.workspace.eventbus.SubscriberTier;
+import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
 import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -211,6 +212,34 @@ public class CompilationServiceImplTest {
         publishWmDocumentChanged(TEST_ROOT);
         Assert.assertTrue(secondCompiled.await(3, TimeUnit.SECONDS),
                 "WM_DOCUMENT_CHANGED should request compilation");
+    }
+
+    @Test
+    public void rmE1_throttlesDocumentTriggeredCompilationUntilWindowExpires() throws InterruptedException {
+        CountDownLatch firstCompiled = new CountDownLatch(1);
+        CountDownLatch throttledCompilation = new CountDownLatch(1);
+        AtomicInteger compileCount = new AtomicInteger(0);
+        service = new CompilationServiceImpl(snapshotStore, eventBus, task -> {
+            int count = compileCount.incrementAndGet();
+            if (count == 1) {
+                firstCompiled.countDown();
+            } else if (count == 2) {
+                throttledCompilation.countDown();
+            }
+            return mockSnapshot;
+        }, 50L, 300L);
+
+        publishWmE1(TEST_ROOT);
+        Assert.assertTrue(firstCompiled.await(3, TimeUnit.SECONDS), "Initial compilation");
+
+        eventBus.publish(new DomainEvent(Instant.now(), "resource-monitor",
+                EventKind.RM_E1_HEAP_PRESSURE_DETECTED, HeapPressureLevel.WARNING.name()));
+        publishWmDocumentChanged(TEST_ROOT);
+
+        Assert.assertFalse(throttledCompilation.await(150, TimeUnit.MILLISECONDS),
+                "RM-E1 should throttle immediate document-triggered recompilation");
+        Assert.assertTrue(throttledCompilation.await(2, TimeUnit.SECONDS),
+                "Compilation should resume after the throttle window");
     }
 
     @Test

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CrossContextBoundaryTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/test/acceptance/CrossContextBoundaryTest.java
@@ -17,139 +17,288 @@
  */
 package org.ballerinalang.langserver.workspace.test.acceptance;
 
-import org.ballerinalang.langserver.workspace.compilerengine.CompilationService;
-import org.ballerinalang.langserver.workspace.lspgateway.ClientSession;
-import org.ballerinalang.langserver.workspace.lspgateway.WorkspaceManagerFacadeImpl;
-import org.ballerinalang.langserver.workspace.workspacemanager.ProjectService;
-import org.mockito.Mockito;
+import io.ballerina.projects.PackageCompilation;
+import org.ballerinalang.langserver.workspace.compilerengine.CompilationPipeline;
+import org.ballerinalang.langserver.workspace.compilerengine.CompilationServiceImpl;
+import org.ballerinalang.langserver.workspace.compilerengine.DualSnapshotStore;
+import org.ballerinalang.langserver.workspace.compilerengine.MaterializedStableSnapshot;
+import org.ballerinalang.langserver.workspace.compilerengine.StableSnapshot;
+import org.ballerinalang.langserver.workspace.documentstore.ContentVersion;
+import org.ballerinalang.langserver.workspace.eventbus.DomainEvent;
+import org.ballerinalang.langserver.workspace.eventbus.EventKind;
+import org.ballerinalang.langserver.workspace.eventbus.EventSyncPubSubHolder;
+import org.ballerinalang.langserver.workspace.resourcemonitor.HeapPressureLevel;
+import org.ballerinalang.langserver.workspace.workspacemanager.ChangeBuffer;
+import org.ballerinalang.langserver.workspace.workspacemanager.HeapEstimate;
+import org.ballerinalang.langserver.workspace.workspacemanager.MemoryBudget;
+import org.ballerinalang.langserver.workspace.workspacemanager.Project;
+import org.ballerinalang.langserver.workspace.workspacemanager.ProjectHealthState;
+import org.ballerinalang.langserver.workspace.workspacemanager.ProjectKind;
+import org.ballerinalang.langserver.workspace.workspacemanager.ProjectLoader;
+import org.ballerinalang.langserver.workspace.workspacemanager.ProjectRegistry;
+import org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceImpl;
+import org.ballerinalang.langserver.workspace.workspacemanager.SourceRoot;
+import org.ballerinalang.langserver.workspace.workspacemanager.UriResolver;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
 
 /**
- * Acceptance tests for cross-context boundary enforcement.
+ * Acceptance tests for v2.0 cross-context boundaries after the DS+WM merge.
  *
  * @since 1.7.0
  */
 public class CrossContextBoundaryTest {
 
-    private static final String BASE_PACKAGE = "org.ballerinalang.langserver.workspace";
-    private static final String[] BOUNDED_CONTEXTS = {
-            "lspgateway", "workspacemanager", "compilerengine", "documentstore", "executionmanager", "observability", "eventbus"
-    };
+    private EventSyncPubSubHolder eventBus;
+    private ProjectRegistry registry;
+    private UriResolver uriResolver;
+    private ChangeBuffer changeBuffer;
+    private ProjectServiceImpl projectService;
+    private CompilationServiceImpl compilationService;
+    private Path tempDir;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        eventBus = new EventSyncPubSubHolder();
+        registry = new ProjectRegistry(MemoryBudget.ofMb(1024));
+        uriResolver = new UriResolver();
+        changeBuffer = new ChangeBuffer();
+        tempDir = Files.createTempDirectory("cross-context-boundary");
+        Files.writeString(tempDir.resolve("Ballerina.toml"), "[package]\norg = \"test\"\nname = \"cross\"\n");
+        Files.writeString(tempDir.resolve("main.bal"), "public function main() {}\n");
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (compilationService != null) {
+            compilationService.close();
+            compilationService = null;
+        }
+        if (projectService != null) {
+            projectService.shutdown();
+            projectService = null;
+        }
+        if (eventBus != null) {
+            eventBus.close();
+            eventBus = null;
+        }
+        if (registry != null) {
+            registry.shutdown();
+            registry = null;
+        }
+        deleteRecursive(tempDir);
+    }
 
     @Test
-    public void testLspHandlersDependOnlyOnWorkspaceManagerInterface() throws IOException {
-        // RED: this test should fail — check for direct bounded context imports in handlers
-        Path handlerRoot = Paths.get("src/main/java/org/ballerinalang/langserver");
-        if (!Files.exists(handlerRoot)) {
-            handlerRoot = Paths.get("langserver-core/src/main/java/org/ballerinalang/langserver");
-        }
-        List<Path> handlerFiles = findJavaFiles(handlerRoot, "workspace");
+    public void wmDocumentChanged_crossesToCompilerEngineAndTriggersCompilation() throws Exception {
+        // RED: this test should fail — WM->CE compilation trigger wiring is not yet verified here
+        AtomicInteger compileCount = new AtomicInteger();
+        CountDownLatch secondCompilation = new CountDownLatch(1);
+        compilationService = new CompilationServiceImpl(new DualSnapshotStore(), eventBus,
+                countingAction(compileCount, secondCompilation), 50L);
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        Path mainFile = tempDir.resolve("main.bal");
+        eventBus.publish(new DomainEvent(Instant.now(), root.path().toString(), EventKind.WORKSPACE_PROJECT_REGISTERED));
 
-        for (Path file : handlerFiles) {
-            List<String> lines = Files.readAllLines(file);
-            for (String line : lines) {
-                if (line.trim().startsWith("import ")) {
-                    for (String bc : BOUNDED_CONTEXTS) {
-                        String forbiddenImport = BASE_PACKAGE + "." + bc;
-                        // Allow imports from facade and interfaces if they are public
-                        // But ADR-031 says no sibling context's internal classes.
-                        // WorkspaceManager is at the root of workspace package.
-                        Assert.assertFalse(line.contains(forbiddenImport),
-                                "LSP handler " + file.getFileName() + " violates boundary by importing " + forbiddenImport);
-                    }
+        Assert.assertTrue(awaitCompileCount(compileCount, 1, 3), "Project registration should trigger initial compile");
+
+        eventBus.publish(new DomainEvent(Instant.now(), root.path().toString(), EventKind.WM_DOCUMENT_CHANGED,
+                mainFile.toString()));
+
+        Assert.assertTrue(secondCompilation.await(3, TimeUnit.SECONDS),
+                "WM_DOCUMENT_CHANGED should trigger a second compilation in CE");
+    }
+
+    @Test
+    public void rmHeapPressure_crossesToProjectServiceAndEvictsBackgroundProjects() throws Exception {
+        projectService = createProjectService();
+        SourceRoot activeRoot = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        SourceRoot backgroundRoot = new SourceRoot(tempDir.resolve("background").toAbsolutePath().normalize());
+
+        Project activeProject = new Project(activeRoot, ProjectKind.BUILD, HeapEstimate.ofMb(64));
+        Project backgroundProject = new Project(backgroundRoot, ProjectKind.BUILD, HeapEstimate.ofMb(64));
+        activeProject.openDocumentCount().increment();
+        registry.register(activeRoot, activeProject);
+        registry.register(backgroundRoot, backgroundProject);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "resource-monitor",
+                EventKind.RM_E1_HEAP_PRESSURE_DETECTED, HeapPressureLevel.WARNING.name()));
+
+        Assert.assertTrue(awaitCondition(() -> registry.get(activeRoot).isPresent(), 3),
+                "Active project should remain after RM_E1");
+        Assert.assertTrue(awaitCondition(() -> registry.get(backgroundRoot).isEmpty(), 3),
+                "Background project should be evicted after RM_E1");
+    }
+
+    @Test
+    public void rmHeapPressure_crossesToCompilerEngineAndThrottlesCompilation() throws Exception {
+        AtomicInteger compileCount = new AtomicInteger();
+        CountDownLatch throttledCompilation = new CountDownLatch(1);
+        compilationService = new CompilationServiceImpl(new DualSnapshotStore(), eventBus,
+                countingAction(compileCount, throttledCompilation), 50L, 300L);
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        Path mainFile = tempDir.resolve("main.bal");
+        eventBus.publish(new DomainEvent(Instant.now(), root.path().toString(), EventKind.WORKSPACE_PROJECT_REGISTERED));
+        Assert.assertTrue(awaitCompileCount(compileCount, 1, 3), "Project registration should trigger initial compile");
+
+        eventBus.publish(new DomainEvent(Instant.now(), "resource-monitor",
+                EventKind.RM_E1_HEAP_PRESSURE_DETECTED, HeapPressureLevel.WARNING.name()));
+        eventBus.publish(new DomainEvent(Instant.now(), root.path().toString(), EventKind.WM_DOCUMENT_CHANGED,
+                mainFile.toString()));
+
+        Assert.assertFalse(throttledCompilation.await(150, TimeUnit.MILLISECONDS),
+                "RM_E1 should throttle immediate recompilation requests in CE");
+        Assert.assertTrue(throttledCompilation.await(2, TimeUnit.SECONDS),
+                "Compilation should resume after the throttle window expires");
+    }
+
+    @Test
+    public void ceE5a_crossesToProjectServiceAndIsRecorded() throws Exception {
+        projectService = createProjectService();
+        Path mainFile = tempDir.resolve("main.bal");
+        projectService.loadOrCreate(mainFile, () -> { });
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+
+        eventBus.publish(new DomainEvent(Instant.now(), "compiler-engine",
+                EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY, root.path().toString()));
+
+        Assert.assertTrue(awaitCondition(() -> hasObservedCompilerSignal(root, EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY), 3),
+                "CE-E5a should be observed by ProjectService");
+    }
+
+    @Test
+    public void ceE5b_crossesToProjectServiceAndRestoresHealthyState() throws Exception {
+        projectService = createProjectService();
+        Path mainFile = tempDir.resolve("main.bal");
+        projectService.loadOrCreate(mainFile, () -> { });
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        Project project = registry.get(root).orElseThrow();
+        project.notifySourceChanged();
+        project.transitionTo(ProjectHealthState.COMPILATION_CRASHED);
+        project.transitionTo(ProjectHealthState.RECOVERING);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "compiler-engine",
+                EventKind.CE_E5B_COMPILATION_DIAGNOSTICS_READY, root.path().toString()));
+
+        Assert.assertTrue(awaitCondition(() -> project.healthState() == ProjectHealthState.HEALTHY, 3),
+                "CE-E5b should restore a recovering project to HEALTHY");
+    }
+
+    @Test
+    public void ceResolutionExhausted_crossesToProjectServiceAndOpensCircuit() throws Exception {
+        projectService = createProjectService();
+        Path mainFile = tempDir.resolve("main.bal");
+        projectService.loadOrCreate(mainFile, () -> { });
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        Project project = registry.get(root).orElseThrow();
+        project.transitionTo(ProjectHealthState.PROJECT_CRASHED);
+        project.transitionTo(ProjectHealthState.RECOVERING);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "compiler-engine",
+                EventKind.CE_RESOLUTION_EXHAUSTED, root.path().toString()));
+
+        Assert.assertTrue(awaitCondition(() -> project.healthState() == ProjectHealthState.CIRCUIT_OPEN, 3),
+                "CE resolution exhaustion should move a recovering project to CIRCUIT_OPEN");
+    }
+
+    @Test
+    public void ceResolutionRecovered_crossesToProjectServiceAndReturnsToRecovering() throws Exception {
+        projectService = createProjectService();
+        Path mainFile = tempDir.resolve("main.bal");
+        projectService.loadOrCreate(mainFile, () -> { });
+        SourceRoot root = new SourceRoot(tempDir.toAbsolutePath().normalize());
+        Project project = registry.get(root).orElseThrow();
+        project.transitionTo(ProjectHealthState.PROJECT_CRASHED);
+        project.transitionTo(ProjectHealthState.RECOVERING);
+        project.transitionTo(ProjectHealthState.CIRCUIT_OPEN);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "compiler-engine",
+                EventKind.CE_RESOLUTION_RECOVERED, root.path().toString()));
+
+        Assert.assertTrue(awaitCondition(() -> project.healthState() == ProjectHealthState.RECOVERING, 3),
+                "CE resolution recovery should move a circuit-open project back to RECOVERING");
+    }
+
+    private ProjectServiceImpl createProjectService() {
+        ProjectLoader loader = (root, kind) -> mock(io.ballerina.projects.Project.class);
+        return projectService = new ProjectServiceImpl(registry, uriResolver, eventBus, loader, changeBuffer);
+    }
+
+    private CompilationPipeline.CompilationAction countingAction(AtomicInteger compileCount, CountDownLatch latch) {
+        StableSnapshot snapshot = new MaterializedStableSnapshot(Map.of(), Map.of(), Map.of(),
+                mock(PackageCompilation.class), new ContentVersion(1));
+        return task -> {
+            if (compileCount.incrementAndGet() >= 2) {
+                latch.countDown();
+            }
+            return snapshot;
+        };
+    }
+
+    private boolean hasObservedCompilerSignal(SourceRoot root, EventKind signal) {
+        try {
+            Method method = ProjectServiceImpl.class.getDeclaredMethod("hasObservedCompilerSignal", SourceRoot.class,
+                    EventKind.class);
+            method.setAccessible(true);
+            return (boolean) method.invoke(projectService, root, signal);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("ProjectServiceImpl should expose compiler signal observation for boundary tests", e);
+        }
+    }
+
+    private boolean awaitCompileCount(AtomicInteger compileCount, int expected, int timeoutSeconds) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            if (compileCount.get() >= expected) {
+                return true;
+            }
+            TimeUnit.MILLISECONDS.sleep(25);
+        }
+        return compileCount.get() >= expected;
+    }
+
+    private boolean awaitCondition(CheckedBooleanSupplier condition, int timeoutSeconds) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            TimeUnit.MILLISECONDS.sleep(25);
+        }
+        return condition.getAsBoolean();
+    }
+
+    private static void deleteRecursive(Path path) throws IOException {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (var stream = Files.walk(path)) {
+            stream.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
                 }
-            }
+            });
         }
     }
 
-    @Test
-    public void testFacadeMethodsContainNoDomainLogic() throws IOException {
-        // Verify the facade file exists and is proxy-free.
-        Path facadeFile = Paths.get("src/main/java/org/ballerinalang/langserver/workspace/lspgateway/WorkspaceManagerFacadeImpl.java");
-        if (!Files.exists(facadeFile)) {
-            facadeFile = Paths.get("langserver-core/src/main/java/org/ballerinalang/langserver/workspace/lspgateway/WorkspaceManagerFacadeImpl.java");
-        }
-        String content = Files.readString(facadeFile);
-
-        Assert.assertFalse(content.contains("BallerinaWorkspaceManagerProxy"));
-        Assert.assertFalse(content.contains("WorkspaceManagerProxy"));
-        Assert.assertTrue(Files.exists(facadeFile), "Facade file must exist");
-    }
-
-    @Test
-    public void testFacadeDelegatesToCorrectServices() {
-        ProjectService projectService = Mockito.mock(ProjectService.class);
-        CompilationService compilationService = Mockito.mock(CompilationService.class);
-        ClientSession clientSession = Mockito.mock(ClientSession.class);
-
-        WorkspaceManagerFacadeImpl facade = new WorkspaceManagerFacadeImpl(
-                projectService, compilationService, Mockito.mock(org.ballerinalang.langserver.workspace.executionmanager.ExecutionService.class), clientSession);
-
-        Path path = Paths.get("test.bal");
-
-        // Test project delegation
-        facade.project(path);
-        Mockito.verify(projectService).loadOrCreate(path, null);
-        Mockito.verifyNoInteractions(compilationService);
-
-        // Test compilation-backed semantic model resolution
-        Mockito.reset(projectService, compilationService);
-        io.ballerina.compiler.api.SemanticModel mockModel =
-                Mockito.mock(io.ballerina.compiler.api.SemanticModel.class);
-        io.ballerina.projects.PackageCompilation compilation = Mockito.mock(io.ballerina.projects.PackageCompilation.class);
-        io.ballerina.projects.Project project = Mockito.mock(io.ballerina.projects.Project.class);
-        io.ballerina.projects.DocumentId documentId = Mockito.mock(io.ballerina.projects.DocumentId.class);
-        io.ballerina.projects.ModuleId moduleId = Mockito.mock(io.ballerina.projects.ModuleId.class);
-        Mockito.when(compilationService.compilation(path, null)).thenReturn(compilation);
-        Mockito.when(projectService.loadOrCreate(path, null)).thenReturn(project);
-        Mockito.when(project.documentId(path)).thenReturn(documentId);
-        Mockito.when(documentId.moduleId()).thenReturn(moduleId);
-        Mockito.when(compilation.getSemanticModel(moduleId)).thenReturn(mockModel);
-        facade.semanticModel(path);
-        Mockito.verify(compilationService).compilation(path, null);
-        Mockito.verify(projectService).loadOrCreate(path, null);
-
-        // Test document delegation: document() now uses projectService fallback directly
-        Mockito.reset(projectService, compilationService);
-        facade.document(path);
-        Mockito.verify(projectService).loadOrCreate(path, null);
-        Mockito.verifyNoInteractions(compilationService);
-    }
-
-    @Test
-    public void testPackagePerBoundedContextStructure() throws IOException {
-        // RED: this test should fail — verify package structure
-        Path workspaceRoot = Paths.get("src/main/java/org/ballerinalang/langserver/workspace");
-        if (!Files.exists(workspaceRoot)) {
-            workspaceRoot = Paths.get("langserver-core/src/main/java/org/ballerinalang/langserver/workspace");
-        }
-        for (String bc : BOUNDED_CONTEXTS) {
-            Path bcPath = workspaceRoot.resolve(bc);
-            // Handle execution vs executionmanager
-            if (bc.equals("executionmanager") && !Files.exists(bcPath)) {
-                bcPath = workspaceRoot.resolve("execution");
-            }
-            Assert.assertTrue(Files.exists(bcPath), "Bounded context package missing: " + bc);
-            Assert.assertTrue(Files.isDirectory(bcPath), "Bounded context path is not a directory: " + bc);
-        }
-    }
-
-    private List<Path> findJavaFiles(Path root, String excludeDir) throws IOException {
-        try (Stream<Path> stream = Files.walk(root)) {
-            return stream.filter(Files::isRegularFile)
-                    .filter(p -> p.toString().endsWith(".java"))
-                    .filter(p -> !p.toString().contains(File.separator + excludeDir + File.separator))
-                    .collect(Collectors.toList());
-        }
+    @FunctionalInterface
+    private interface CheckedBooleanSupplier {
+        boolean getAsBoolean() throws Exception;
     }
 }

--- a/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
+++ b/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/workspacemanager/ProjectServiceTest.java
@@ -648,6 +648,61 @@ public class ProjectServiceTest {
         Assert.assertEquals(eventCount, 0, "No health state change should occur if not in RECOVERING");
     }
 
+    @Test(groups = "event-subscription-diagnostics-ready")
+    public void resolutionDiagnosticsReady_recordsCompilerSignalForProject() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+
+        SourceRoot root = new SourceRoot(projectPath);
+        eventBus.publish(new DomainEvent(Instant.now(), "test", EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY,
+                projectPath.toString()));
+        Thread.sleep(100);
+
+        Assert.assertTrue(service.hasObservedCompilerSignal(root, EventKind.CE_E5A_RESOLUTION_DIAGNOSTICS_READY),
+                "ProjectService should record CE-E5a delivery");
+    }
+
+    @Test(groups = "event-subscription-diagnostics-ready")
+    public void resolutionExhausted_recoveringProjectTransitionsToCircuitOpen() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+
+        SourceRoot root = new SourceRoot(projectPath);
+        org.ballerinalang.langserver.workspace.workspacemanager.Project project = registry.get(root).orElseThrow();
+        project.transitionTo(ProjectHealthState.PROJECT_CRASHED);
+        project.transitionTo(ProjectHealthState.RECOVERING);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "test", EventKind.CE_RESOLUTION_EXHAUSTED,
+                projectPath.toString()));
+        Thread.sleep(100);
+
+        Assert.assertEquals(project.healthState(), ProjectHealthState.CIRCUIT_OPEN,
+                "CE-E6 should move RECOVERING projects to CIRCUIT_OPEN");
+        Assert.assertTrue(service.hasObservedCompilerSignal(root, EventKind.CE_RESOLUTION_EXHAUSTED),
+                "ProjectService should record CE-E6 delivery");
+    }
+
+    @Test(groups = "event-subscription-diagnostics-ready")
+    public void resolutionRecovered_circuitOpenProjectTransitionsToRecovering() throws Exception {
+        Path projectPath = tempDir.toAbsolutePath().normalize();
+        service.loadOrCreate(projectPath, cancelChecker);
+
+        SourceRoot root = new SourceRoot(projectPath);
+        org.ballerinalang.langserver.workspace.workspacemanager.Project project = registry.get(root).orElseThrow();
+        project.transitionTo(ProjectHealthState.PROJECT_CRASHED);
+        project.transitionTo(ProjectHealthState.RECOVERING);
+        project.transitionTo(ProjectHealthState.CIRCUIT_OPEN);
+
+        eventBus.publish(new DomainEvent(Instant.now(), "test", EventKind.CE_RESOLUTION_RECOVERED,
+                projectPath.toString()));
+        Thread.sleep(100);
+
+        Assert.assertEquals(project.healthState(), ProjectHealthState.RECOVERING,
+                "CE-E7 should move CIRCUIT_OPEN projects back to RECOVERING");
+        Assert.assertTrue(service.hasObservedCompilerSignal(root, EventKind.CE_RESOLUTION_RECOVERED),
+                "ProjectService should record CE-E7 delivery");
+    }
+
     // =========================================================================
     // Watched File Change Tests
     // =========================================================================


### PR DESCRIPTION
## Purpose

Align the workspace boundary tests with the merged WM architecture and
restore the missing cross-context behavior expected by the new model.

## Approach

Updated the acceptance coverage to exercise the remaining real boundaries
between WM, CE, and RM. Added the minimal runtime handling needed for CE
signals and RM heap-pressure throttling so the tests reflect current
behavior.

## What Was Fixed / Changed

- Reworked `CrossContextBoundaryTest` for WM→CE, RM→WM, RM→CE, and CE→WM
  flows.
- Added CE signal tracking and state transitions in `ProjectServiceImpl`.
- Added RM-E1 throttling for document-triggered recompilation in
  `CompilationServiceImpl`.
- Removed proxy-era assumptions from the boundary coverage.

## Affected Components

- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/compilerengine/`
- `langserver-core/src/main/java/org/ballerinalang/langserver/workspace/workspacemanager/`
- `langserver-core/src/test/java/org/ballerinalang/langserver/workspace/`

## How Has This Been Tested

Selected Gradle tests only:

- `org.ballerinalang.langserver.workspace.test.acceptance.CrossContextBoundaryTest`
- `org.ballerinalang.langserver.workspace.workspacemanager.ProjectServiceTest`
- `org.ballerinalang.langserver.workspace.compilerengine.CompilationServiceImplTest`

## Remarks & Notes

Full suite was not run per instruction. No TODOs or FIXMEs were introduced.
